### PR TITLE
Notify receiver about sent sats

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -99,7 +99,7 @@ A big thanks the people over at LightningTipBot and @AE9999. This fork-project i
 - automatically creates a lightning address for the user which is display in the !help command
 - send info when created invoice has been paid (✅)
 - limit usage to specific matrix instances
-- Inform users about donated funds.
+- Inform users about donated funds (✅)
 - Graceliously handle multiple bots is a single
 - integrate a fiat/rate conversion tool (✅)
 - send sats directly to a lightning address (✅)

--- a/src/matrix_bot/business_logic.rs
+++ b/src/matrix_bot/business_logic.rs
@@ -215,20 +215,29 @@ impl BusinessLogicContext {
                    "Could not pay invoice");
             }
         }
- 
-        if memo.is_some() {
-            Ok(CommandReply::text_only(format!("{:?} sent {:?} Sats to {:?} with memo {:?}",
-                                              sender,
-                                              amount,
-                                              recipient,
-                                              memo.clone().unwrap()).as_str()))
+        let mut reply = if memo.is_some() {
+            CommandReply::text_only(format!("{:?} sent {:?} Sats to {:?} with memo {:?}",
+                                             sender,
+                                             amount,
+                                             recipient,
+                                             memo.clone().unwrap()).as_str())
+        } else {
+            CommandReply::text_only(format!("{:?} sent {:?} Sats to {:?}",
+                                             sender,
+                                             amount,
+                                             recipient).as_str())
+        };
+
+        if parse_lnurl(recipient).is_none() {
+            let receiver_msg = if memo.is_some() {
+                format!("{} you received {} Sats from {} with memo {}", recipient, amount, sender, memo.clone().unwrap())
+            } else {
+                format!("{} you received {} Sats from {}", recipient, amount, sender)
+            };
+            reply.receiver_message = Some(receiver_msg);
         }
-        else {
-            Ok(CommandReply::text_only(format!("{:?} sent {:?} Sats to {:?}",
-                                              sender,
-                                              amount,
-                                              recipient).as_str()))
-        }
+
+        Ok(reply)
     }
 
     async fn do_process_invoice(&self,

--- a/src/matrix_bot/commands.rs
+++ b/src/matrix_bot/commands.rs
@@ -22,6 +22,7 @@ pub struct CommandReply {
     pub image: Option<Vec<u8>>,
     pub payment_hash: Option<String>,
     pub in_key: Option<String>,
+    pub receiver_message: Option<String>,
 }
 
 impl Command {
@@ -143,6 +144,7 @@ impl CommandReply {
             image: None,
             payment_hash: None,
             in_key: None,
+            receiver_message: None,
         }
     }
 
@@ -152,6 +154,7 @@ impl CommandReply {
             image: Some(image),
             payment_hash: None,
             in_key: None,
+            receiver_message: None,
         }
     }
 

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -540,6 +540,13 @@ pub mod matrix_bot {
                             _ => { },
                         };
 
+                        if let Some(receiver_text) = command_reply.receiver_message {
+                            let content = RoomMessageEventContent::text_plain(receiver_text);
+                            if let Err(error) = room.send(content).await {
+                                log::warn!("Error occurred while notifying receiver {:?}..", error);
+                            }
+                        }
+
                         //
                         // TODO(AE) This assumes we don't have image only responses fix once
                         // this changes.


### PR DESCRIPTION
## Summary
- extend `CommandReply` with a `receiver_message` field
- build a notification message for the recipient in `do_process_send`
- send the notification message in the matrix bot handler
