### PR TITLE
Fix wallet query for new LNbits API

### DIFF
--- a/src/lnbits_client/mod.rs
+++ b/src/lnbits_client/mod.rs
@@ -188,7 +188,13 @@ pub struct LNBitsClient {
         pub async fn wallets(&self, user: &LNBitsUser) -> Result<Vec<Wallet>, reqwest::Error> {
             let response = self
                 .client
-                .get([self.url.as_str(), "/users/api/v1/wallets/", &*(user.id)].join(""))
+                .get([
+                    self.url.as_str(),
+                    "/users/api/v1/user/",
+                    &*(user.id),
+                    "/wallet/",
+                ]
+                .join(""))
                 .headers(self.headers.clone())
                 .send()
                 .await?


### PR DESCRIPTION
## Summary
- update wallet endpoint path to `/users/api/v1/user/{user_id}/wallet/`