### PR TITLE
Switch to bearer token for LNbits API

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -69,7 +69,7 @@ Construct a file `config.conf` with the following entries:
 --matrix-username=your_user_for_the_bot                # The username of the account your created
 --matrix-password=the_passwort_for_that_user_account   # The password of your matrix bot
 --lnbits-url=http://mylnbitsurl.com                    # The url of your LNbits instance
---lnbits-x-api-key=<LNBITS-X-API-KEY>                  # The user x-api-key for your LNbits instance. See https://github.com/lnbits/lnbits/wiki/LNbits-Extensions on how to obtain it.
+--lnbits-bearer-token=<LNBITS-BEARER-TOKEN>            # Bearer token for your LNbits instance. Use it in the Authorization header.
 --database-url=/db/db.db                               # The absolute path to your generated db.
 ```
 

--- a/example-configs/config.conf
+++ b/example-configs/config.conf
@@ -2,5 +2,5 @@
 --matrix-username=<matrix-bot>
 --matrix-password=<matrix-bot-password>
 --lnbits-url=<url-to-lnbits>
---lnbits-x-api-key=<api-key-for-superuser>
+--lnbits-bearer-token=<bearer-token>
 --database-url=/<path-to-db>/db.db

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ pub mod config {
         pub matrix_username: String,
         pub matrix_password: String,
         pub lnbits_url: String,
-        pub lnbits_x_api_key: String,
+        pub lnbits_bearer_token: String,
         pub database_url: String,
         pub debug_level: String,
         pub donate_user: Option<String>,
@@ -20,7 +20,7 @@ pub mod config {
                    matrix_username: &str,
                matrix_password: &str,
                lnbits_url: &str,
-               lnbits_x_api_key: &str,
+               lnbits_bearer_token: &str,
                database_url: &str,
                debug_level: &str,
                donate_user: Option<&String>,
@@ -30,7 +30,7 @@ pub mod config {
                 matrix_username: matrix_username.to_string(),
                 matrix_password: matrix_password.to_string(),
                 lnbits_url: lnbits_url.to_string(),
-                lnbits_x_api_key: lnbits_x_api_key.to_string(),
+                lnbits_bearer_token: lnbits_bearer_token.to_string(),
                 database_url: database_url.to_string(),
                 debug_level: debug_level.to_string(),
                 donate_user: donate_user.map(|s| s.to_string()),
@@ -67,10 +67,10 @@ pub mod config {
                 .long("lnbits-url")
                 .required(true)
                 .help("lnbits url"))
-            .arg(Arg::new("lnbits-x-api-key")
-                .long("lnbits-x-api-key")
+            .arg(Arg::new("lnbits-bearer-token")
+                .long("lnbits-bearer-token")
                 .required(true)
-                .help("lnbits x api key"))
+                .help("lnbits bearer token"))
             .arg(Arg::new("database-url")
                 .long("database-url")
                 .required(true)
@@ -100,7 +100,7 @@ pub mod config {
 
         let lnbits_url = matches.get_one::<String>("lnbits-url").unwrap();
 
-        let lnbits_x_api_key = matches.get_one::<String>("lnbits-x-api-key").unwrap();
+        let lnbits_bearer_token = matches.get_one::<String>("lnbits-bearer-token").unwrap();
 
         let database_url = matches.get_one::<String>("database-url").unwrap();
 
@@ -114,7 +114,7 @@ pub mod config {
                     matrix_username,
                     matrix_password,
                     lnbits_url,
-                    lnbits_x_api_key,
+                    lnbits_bearer_token,
                     database_url,
                     debug_level,
                     donate_user,

--- a/src/lnbits_client/mod.rs
+++ b/src/lnbits_client/mod.rs
@@ -119,7 +119,7 @@ pub mod lnbits_client {
         }
     }
 
-    use reqwest::{Client, header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE}};
+    use reqwest::{Client, header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE, AUTHORIZATION}};
 
 #[derive(Clone)]
 pub struct LNBitsClient {
@@ -141,8 +141,10 @@ pub struct LNBitsClient {
             headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
             headers.insert(
-                "X-Api-Key",
-                HeaderValue::from_str(config.lnbits_x_api_key.as_str()).unwrap(),
+                AUTHORIZATION,
+                HeaderValue::from_str(
+                    &format!("Bearer {}", config.lnbits_bearer_token)
+                ).unwrap(),
             );
 
             LNBitsClient {


### PR DESCRIPTION
## Summary
- change LNbits auth from `X-Api-Key` header to bearer token
- update configuration options and example config
- adjust README usage instructions