### PR TITLE
Fix config access

### DIFF
--- a/src/matrix_bot/business_logic.rs
+++ b/src/matrix_bot/business_logic.rs
@@ -41,6 +41,10 @@ impl BusinessLogicContext {
         }
     }
 
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
     pub fn get_help_content(&self) -> String {
         format!(
             "Matrix-Lightning-Tip-Bot {}\n{}",

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -462,7 +462,7 @@ pub mod matrix_bot {
                         log::info!("processing event {:?} ..", event);
 
                         let sender = event.sender.as_str();
-                        if !sender_allowed(&event.sender, &business_logic_contex.config) {
+                        if !sender_allowed(&event.sender, business_logic_contex.config()) {
                             log::info!("Ignoring message from disallowed server: {}", event.sender.server_name());
                             return;
                         }


### PR DESCRIPTION
## Summary
- expose config with a getter in `BusinessLogicContext`
- use new getter when checking allowed senders
