### PR TITLE
Store generated LN addresses and display them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-lightning-tip-bot"
-version = "0.7.0"
+version = "0.7.5"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.MD
+++ b/README.MD
@@ -12,21 +12,20 @@ MLTB can either be used directly or be self run. Running your own instance requi
 ## Directly
 I am are running a dedicated MLTB instance over at @lightning-wallet-bot:matrix.yourdevice.ch. Invite it to a room to get started immediately. After joining the bot should display the possible commands which are:
 
-```
-!tip     - Reply to a message to tip it: !tip <amount> [<memo>]
-!generate-ln-address - Get your own LN Address: !generate-ln-address <your address name>
-!balance - Check your balance: !balance
-!send    - Send funds to a user: !send <amount> <@user> or <@user:domain.com> or <lightningadress@yourdomain.com> [<memo>]
-!invoice - Receive over Lightning: !invoice <amount> [<memo>]
-!pay     - Pay an invoice over Lightning: !pay <invoice>
-!transactions - List your transactions: !transactions
-!help    - Read this help.\n\
-!donate  - Donate to the matrix-lighting-tip-bot project: !donate <amount>
-!party   - Start a Party: !party
-!fiat-to-sats - Convert fiat to satoshis: !fiat-to-sats <amount> <currency (USD, EUR, CHF)>
-!sats-to-fiat - Convert satoshis to fiat: !sats-to-fiat <amount> <currency (USD, EUR, CHF)>
-!version - Print the version of this bot
-```
+* **!tip** - Reply to a message to tip it: `!tip <amount> [<memo>]`
+* **!generate-ln-address** - Get your own LN Address: `!generate-ln-address <your address name>`
+* **!show-ln-addresses** - Show your generated LN Addresses: `!show-ln-addresses`
+* **!balance** - Check your balance: `!balance`
+* **!send** - Send funds to a user: `!send <amount> <@user> or <@user:domain.com> or <lightningadress@yourdomain.com> [<memo>]`
+* **!invoice** - Receive over Lightning: `!invoice <amount> [<memo>]`
+* **!pay** - Pay an invoice over Lightning: `!pay <invoice>`
+* **!transactions** - List your transactions: `!transactions`
+* **!help** - Read this help: `!help`
+* **!donate** - Donate to the matrix-lighting-tip-bot project: `!donate <amount>`
+* **!party** - Start a Party: `!party`
+* **!fiat-to-sats** - Convert fiat to satoshis: `!fiat-to-sats <amount> <currency (USD, EUR, CHF)>`
+* **!sats-to-fiat** - Convert satoshis to fiat: `!sats-to-fiat <amount> <currency (USD, EUR, CHF)>`
+* **!version** - Print the version of this bot: `!version`
 
 ## Running your own instance
 We recommend running your own MLTB instance using Docker https://www.docker.com/.
@@ -109,4 +108,4 @@ A big thanks the people over at LightningTipBot and @AE9999. This fork-project i
 - integrate a fiat/rate conversion tool (✅)
 - send sats directly to a lightning address (✅)
 - list your transactions through the bot (✅)
-- show your ln-address again
+- show your ln-address again (✅)

--- a/migrations/2025-06-23-000001_ln_addresses/down.sql
+++ b/migrations/2025-06-23-000001_ln_addresses/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE ln_addresses;

--- a/migrations/2025-06-23-000001_ln_addresses/up.sql
+++ b/migrations/2025-06-23-000001_ln_addresses/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "ln_addresses" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    matrix_id TEXT NOT NULL,
+    ln_address TEXT NOT NULL,
+    lnurl TEXT NOT NULL,
+    date_created TEXT NOT NULL
+);

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,7 @@ pub mod config {
         ).unwrap();
 
         let matches = Command::new("LN-Matrix-Bot")
-            .version("0.6.0")
+            .version("0.7.5")
             .author("AE")
             .about("LN-Matrix-Bot")
             .arg(Arg::new("matrix-server")

--- a/src/data_layer/mod.rs
+++ b/src/data_layer/mod.rs
@@ -6,10 +6,14 @@ pub mod data_layer {
     use diesel::prelude::*;
 
     use crate::Config;
-    pub  use crate::data_layer::models::{LNBitsId, MatrixId2LNBitsId, NewMatrixId2LNBitsId};
+    pub  use crate::data_layer::models::{
+        LNBitsId, MatrixId2LNBitsId, NewMatrixId2LNBitsId,
+        LnAddress, NewLnAddress,
+    };
     use crate::data_layer::schema;
 
     use schema::matrix_id_2_lnbits_id::dsl::*;
+    use schema::ln_addresses::dsl as ln_addresses_dsl;
 
     #[derive(Clone)]
     pub struct DataLayer {
@@ -50,6 +54,22 @@ pub mod data_layer {
                                                   .load::<MatrixId2LNBitsId>(&mut connection)
                                                   .expect("Error looking up stuff");
             result.remove(0).get_lnbits_id()
+        }
+
+        pub fn insert_ln_address(&self, new_ln_address: NewLnAddress) {
+            let mut connection = self.establish_connection();
+            diesel::insert_into(schema::ln_addresses::table)
+                .values(&new_ln_address)
+                .execute(&mut connection)
+                .expect("Error saving ln address");
+        }
+
+        pub fn ln_addresses_for_matrix_id(&self, matrix_id_: &str) -> Vec<LnAddress> {
+            let mut connection = self.establish_connection();
+            ln_addresses_dsl::ln_addresses
+                .filter(ln_addresses_dsl::matrix_id.eq(matrix_id_))
+                .load::<LnAddress>(&mut connection)
+                .expect("Error loading ln addresses")
         }
     }
 }

--- a/src/data_layer/models.rs
+++ b/src/data_layer/models.rs
@@ -49,3 +49,31 @@ impl LNBitsId {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize, Queryable, Identifiable)]
+#[diesel(table_name = ln_addresses)]
+pub struct LnAddress {
+    pub id: Option<i32>,
+    pub matrix_id: String,
+    pub ln_address: String,
+    pub lnurl: String,
+    pub date_created: String,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = ln_addresses)]
+pub struct NewLnAddress<'a> {
+    pub matrix_id: &'a str,
+    pub ln_address: &'a str,
+    pub lnurl: &'a str,
+    pub date_created: &'a str,
+}
+
+impl NewLnAddress<'_> {
+    pub fn new<'a>(matrix_id: &'a str,
+                   ln_address: &'a str,
+                   lnurl: &'a str,
+                   date_created: &'a str) -> NewLnAddress<'a> {
+        NewLnAddress { matrix_id, ln_address, lnurl, date_created }
+    }
+}

--- a/src/data_layer/schema.rs
+++ b/src/data_layer/schema.rs
@@ -8,3 +8,13 @@ diesel::table! {
         date_created -> Text,
     }
 }
+
+diesel::table! {
+    ln_addresses (id) {
+        id -> Integer,
+        matrix_id -> Text,
+        ln_address -> Text,
+        lnurl -> Text,
+        date_created -> Text,
+    }
+}

--- a/src/matrix_bot/commands.rs
+++ b/src/matrix_bot/commands.rs
@@ -12,6 +12,7 @@ pub enum Command  {
     Party   { },
     Version { },
     GenerateLnAddress { sender: String, username: String },
+    ShowLnAddresses { sender: String },
     FiatToSats { sender: String, amount: f64, currency: String },
     SatsToFiat { sender: String, amount: u64, currency: String },
     Transactions { sender: String },
@@ -125,6 +126,10 @@ pub fn generate_ln_address(sender: &str, text: &str) -> Result<Command, SimpleEr
     }
     let username = split[1].to_string();
     Ok(Command::GenerateLnAddress { sender: sender.to_string(), username })
+}
+
+pub fn show_ln_addresses(sender: &str) -> Result<Command, SimpleError> {
+    Ok(Command::ShowLnAddresses { sender: sender.to_string() })
 }
 
 pub fn fiat_to_sats(sender: &str, text: &str) -> Result<Command, SimpleError> {

--- a/src/matrix_bot/utils.rs
+++ b/src/matrix_bot/utils.rs
@@ -11,3 +11,32 @@ pub fn parse_lnurl(input: &str) -> Option<LnUrl> {
         },
     }
 }
+
+pub fn markdown_to_html(input: &str) -> String {
+    let mut result = String::new();
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\n' {
+            result.push_str("<br>");
+        } else if ch == '*' {
+            if chars.peek() == Some(&'*') {
+                chars.next();
+                result.push_str("<strong>");
+                while let Some(c) = chars.next() {
+                    if c == '*' && chars.peek() == Some(&'*') {
+                        chars.next();
+                        result.push_str("</strong>");
+                        break;
+                    } else {
+                        result.push(c);
+                    }
+                }
+            } else {
+                result.push(ch);
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}


### PR DESCRIPTION
## Summary
- add new database table `ln_addresses`
- save generated LN addresses when using `!generate-ln-address`
- implement `!show-ln-addresses` command to display saved addresses
- wire new command into bot and update help text
- document new command in README
