### PR TITLE
Simplify AS client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde_yaml = "0.9"
 ruma = { version = "0.12.3", features = ["appservice-api", "client-api"] }
 tempfile = "3.10.1"
 regex = "1"
+urlencoding = "2.1.2"
 
 [[bin]]
 name = "generate_registration"

--- a/src/as_client.rs
+++ b/src/as_client.rs
@@ -1,6 +1,8 @@
 use reqwest::{Client, StatusCode};
 use serde_json::json;
 use crate::config::config::Config;
+use url::Url;
+use uuid::Uuid;
 
 pub struct MatrixAsClient {
     homeserver: String,
@@ -13,47 +15,40 @@ impl MatrixAsClient {
     pub fn new(config: &Config) -> Self {
         Self {
             homeserver: config.matrix_server.clone(),
-        let _ = self
-            .post(url)
-            .await;
-        );
-            .http
-            .get(&url)
-            .query(&self.auth_query())
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status() == StatusCode::OK => {
-                match resp.json::<serde_json::Value>().await {
-                    Ok(val) => val.get("membership").and_then(|m| m.as_str()) == Some("join"),
-                    Err(_) => false,
-                }
-            }
-            _ => false,
-        };
-
-        if !joined {
-            self.join_room(room_id).await;
+            user_id: format!(
+                "@{}:{}",
+                config.registration.sender_localpart,
+                Url::parse(&config.matrix_server)
+                    .unwrap()
+                    .host_str()
+                    .unwrap(),
+            ),
+            as_token: config.registration.app_token.clone(),
+            http: Client::new(),
         }
     }
 
-    pub async fn join_room(&self, room_id: &str) {
-        let url = format!("{}/_matrix/client/v3/rooms/{}/join", self.homeserver, room_id);
-        let _ = self.http.post(url)
-            .query(&self.auth_query())
-            .send()
-            .await;
+    fn auth_query(&self) -> Vec<(&str, String)> {
+        vec![
+            ("user_id", self.user_id.clone()),
+            ("access_token", self.as_token.clone()),
+        ]
+    }
+
+    pub fn user_id(&self) -> &str {
+        &self.user_id
     }
 
     pub async fn send_text(&self, room_id: &str, body: &str) {
-        self.ensure_joined(room_id).await;
-        let txn = format!("{}", uuid::Uuid::new_v4());
+        let txn = Uuid::new_v4().to_string();
         let url = format!(
             "{}/_matrix/client/v3/rooms/{}/send/m.room.message/{}",
             self.homeserver, room_id, txn
         );
         let content = json!({"msgtype": "m.text", "body": body});
-        let _ = self.http.put(url)
+        let _ = self
+            .http
+            .put(url)
             .query(&self.auth_query())
             .json(&content)
             .send()
@@ -61,8 +56,7 @@ impl MatrixAsClient {
     }
 
     pub async fn send_raw(&self, room_id: &str, event_type: &str, content: serde_json::Value) {
-        self.ensure_joined(room_id).await;
-        let txn = uuid::Uuid::new_v4().to_string();
+        let txn = Uuid::new_v4().to_string();
         let url = format!(
             "{}/_matrix/client/v3/rooms/{}/send/{}/{}",
             self.homeserver, room_id, event_type, txn
@@ -96,7 +90,6 @@ impl MatrixAsClient {
             Err(_) => None,
         }
     }
-
 
     pub async fn get_event(&self, room_id: &str, event_id: &str) -> Option<serde_json::Value> {
         let url = format!(

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -35,6 +35,15 @@ impl MatrixBot {
     }
 
     pub async fn init(&self) {
+        match self.as_client.user_exists().await {
+            Some(true) => {}
+            Some(false) => {
+                self.as_client.register_user().await;
+            }
+            None => {
+                log::warn!("Failed to check bot user profile");
+            }
+        }
         log::info!("MatrixBot initialized");
     }
 

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -35,7 +35,7 @@ impl MatrixBot {
     }
 
     pub async fn init(&self) {
-        // Application Service users are provisioned automatically on first use.
+        log::info!("MatrixBot initialized");
     }
 
     pub async fn sync(&self) -> Result<(), Box<dyn std::error::Error>> {
@@ -67,18 +67,7 @@ impl MatrixBot {
                         }
                     }
                 }
-                Some("m.room.member") => {
-                    if ev
-                        .get("content")
-                        .and_then(|c| c.get("membership"))
-                        .and_then(|m| m.as_str())
-                        == Some("invite")
-                    {
-                        if let Some(room_id) = ev.get("room_id").and_then(|r| r.as_str()) {
-                            self.as_client.join_room(room_id).await;
-                        }
-                    }
-                }
+                Some("m.room.member") => {}
                 _ => {}
             }
         }


### PR DESCRIPTION
## Summary
- remove custom provisioning logic from Matrix AS client
- send events without checking membership
- drop invite join logic and just log when init

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685e9932b4f8832e985876f4d5a3738c