### PR TITLE
Handle AS invites and presence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde_yaml = "0.9"
 ruma = { version = "0.12.3", features = ["appservice-api", "client-api"] }
 tempfile = "3.10.1"
 regex = "1"
+urlencoding = "2.1.2"
 
 [[bin]]
 name = "generate_registration"

--- a/README.MD
+++ b/README.MD
@@ -151,16 +151,16 @@ sudo docker run -d \
 --lnbits-api-key=xxx
 ```
 
-The bot exposes the Matrix Application Service API at the `url` given in the registration file. The port and **path** from that URL are used for the embedded HTTP server. Ensure your homeserver posts transactions to the same path.
+The bot exposes the Matrix Application Service API at the `url` given in the registration file. The server listens on the port from that URL. Ensure your homeserver posts transactions to the `/` paths defined in the spec.
 Your homeserver **must** be able to reach this address and is responsible for
 pushing events there. Once the registration file is listed under
 `app_service_config_files`, Synapse will POST transactions to
 `/_matrix/app/v1/transactions/{txnId}` at that URL. The bot does not call
-`/sync`; all events are delivered via these transactions. The bot verifies the request's
-`access_token` query parameter matches the `hs_token` from the registration
-file so that only your homeserver can deliver events. Queries to
-`/_matrix/app/v1/users/{userId}` follow the same rule and will return
-`401 Unauthorized` if the token is missing or incorrect.
+`/sync`; all events are delivered via these transactions. The bot verifies that
+transactions include the correct `access_token` so only your homeserver can
+deliver events. Queries to
+`/_matrix/app/v1/users/{userId}` are publicly accessible and simply indicate
+whether that user is registered.
 Transactions use the standard [push events](https://spec.matrix.org/latest/application-service-api/#put_matrixappv1transactionstxnid)
 format so the JSON body may contain `events`, `ephemeral`, `de.sorunome.msc2409.to_device`, and other optional fields.
 


### PR DESCRIPTION
## Summary
- remove leftover provisioning helpers
- join invited rooms using application service token
- set bot presence to "online" at startup
- add `urlencoding` helper
- validate Application Service requests via header or query token
- reply with HTTP 403 and JSON when auth token is invalid
- enforce matching query token when `Authorization` header is present
- expose health check at `/_matrix/app/v1/health`
- strip registration URL path from server routes and document spec paths
- drop access token check from user queries

## Testing
- `cargo check`
- `cargo fmt --all` *(failed: component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e9932b4f8832e985876f4d5a3738c