### PR TITLE
Handle encryption outgoing requests

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -17,7 +17,7 @@ I am are running a dedicated MLTB instance over at @lightning-wallet-bot:matrix.
 * **!show-ln-addresses** - Show your generated LN Addresses: `!show-ln-addresses`
 * **!balance** - Check your balance: `!balance`
 * **!send** - Send funds to a user: `!send <amount> <@user> or <@user:domain.com> or <lightningadress@yourdomain.com> [<memo>]`
-* **!invoice** - Receive over Lightning: `!invoice <amount> [<memo>]`
+* **!invoice** - Receive over Lightning: `!invoice <amount> [<memo>]` (includes a QR code)
 * **!pay** - Pay an invoice over Lightning: `!pay <invoice>`
 * **!transactions** - List your transactions: `!transactions`
 * **!link-to-zeus-wallet** - Connect your wallet in Zeus: `!link-to-zeus-wallet`
@@ -79,6 +79,8 @@ as_token: "<app-service-token>"
 hs_token: "<homeserver-token>"
 sender_localpart: "lightning-bot"
 url: "http://localhost:9000"
+de.sorunome.msc2409.push_ephemeral: true
+receive_ephemeral: true
 namespaces:
   users:
     - regex: "@lightning-bot:.*"
@@ -103,8 +105,9 @@ cargo run --bin generate_registration -- \
 ```
 
 The command writes `registration.yaml` with random tokens similar to the
-example above. Register this file with your homeserver and pass the path via
-`--registration-file` when starting the bot.
+example above and already enables ephemeral event support. Register this file
+with your homeserver and pass the path via `--registration-file` when starting
+the bot.
 
 ### Construct a config file
 Construct a file `config.conf` with the following entries. The LNbits API key is
@@ -123,7 +126,8 @@ used for creating lightning addresses without the bearer token:
 
 `--store-path` only controls where temporary cache files are placed.
 Encrypted client keys are automatically saved in the database's `matrix_store` table.
-If `--avatar-path` is set, the bot sets its avatar URL to this mxc link at startup.
+If `--avatar-path` is set, the bot sets its avatar URL to this `mxc` link at startup
+using `PUT /_matrix/client/v3/profile/{userId}/avatar_url`.
 
 ### Running
 Run `docker run --rm  -v <path-to-config-directory>:/config/  -v <path-to-database-directory>:/db  matrix-lightning-tip-bot  matrix-lightning-tip-bot @/config/config.conf` to start the MLTB container.
@@ -151,18 +155,23 @@ sudo docker run -d \
 --lnbits-api-key=xxx
 ```
 
-The bot exposes the Matrix Application Service API at the `url` given in the registration file. The server listens on the port from that URL. Ensure your homeserver posts transactions to the `/` paths defined in the spec.
+The bot exposes the Matrix Application Service API at the `url` given in the registration file. The server listens on the port from that URL. Ensure your homeserver sends transactions using `PUT` requests to the `/` paths defined in the spec.
 Your homeserver **must** be able to reach this address and is responsible for
 pushing events there. Once the registration file is listed under
-`app_service_config_files`, Synapse will POST transactions to
+`app_service_config_files`, Synapse will PUT transactions to
 `/_matrix/app/v1/transactions/{txnId}` at that URL. The bot does not call
 `/sync`; all events are delivered via these transactions. The bot verifies that
 transactions include the correct `access_token` so only your homeserver can
 deliver events. Queries to
-`/_matrix/app/v1/users/{userId}` are publicly accessible and simply indicate
+`GET /_matrix/app/v1/users/{userId}` is publicly accessible and simply indicates
 whether that user is registered.
 Transactions use the standard [push events](https://spec.matrix.org/latest/application-service-api/#put_matrixappv1transactionstxnid)
-format so the JSON body may contain `events`, `ephemeral`, `de.sorunome.msc2409.to_device`, and other optional fields.
+format so the JSON body may contain `events`, `ephemeral`, `de.sorunome.msc2409.send_to_device`, and other optional fields.
+
+For end-to-end encryption the bot relies on the Matrix Client-Server API
+endpoints `POST /_matrix/client/v3/keys/upload`, `POST /_matrix/client/v3/keys/query`
+and `POST /_matrix/client/v3/keys/claim`. These requests are issued automatically
+whenever new keys need to be uploaded or claimed.
 
 The bot checks each room for the `m.room.encryption` state event before sending a message. Messages to encrypted rooms are locally encrypted, while unencrypted rooms receive plain text.
 Example code:
@@ -178,7 +187,10 @@ async fn room_is_encrypted(&self, room_id: &str) -> bool {
 
 async fn send_message(&self, room_id: &str, body: &str) {
     if self.room_is_encrypted(room_id).await {
-        let (ty, content) = self.encryption.encrypt_text(room_id, body).await;
+        let (ty, content) = self
+            .encryption
+            .encrypt_text(room_id, body, &self.as_client)
+            .await;
         self.as_client.send_raw(room_id, &ty, content).await;
     } else {
         self.as_client.send_text(room_id, body).await;
@@ -200,7 +212,10 @@ async fn room_is_encrypted(&self, room_id: &str) -> bool {
 
 async fn send_message(&self, room_id: &str, body: &str) {
     if self.room_is_encrypted(room_id).await {
-        let (ty, content) = self.encryption.encrypt_text(room_id, body).await;
+        let (ty, content) = self
+            .encryption
+            .encrypt_text(room_id, body, &self.as_client)
+            .await;
         self.as_client.send_raw(room_id, &ty, content).await;
     } else {
         self.as_client.send_text(room_id, body).await;

--- a/migrations/2025-06-27-000003_dm_rooms/down.sql
+++ b/migrations/2025-06-27-000003_dm_rooms/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE dm_rooms;

--- a/migrations/2025-06-27-000003_dm_rooms/up.sql
+++ b/migrations/2025-06-27-000003_dm_rooms/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE dm_rooms (
+    matrix_id TEXT PRIMARY KEY,
+    room_id TEXT NOT NULL
+);

--- a/src/application_service/registration.rs
+++ b/src/application_service/registration.rs
@@ -35,6 +35,9 @@ pub struct Registration {
     #[serde(rename = "push_ephemeral", skip_serializing_if = "Option::is_none")]
     pub ephemeral_events: Option<bool>,
 
+    #[serde(rename = "receive_ephemeral", skip_serializing_if = "Option::is_none")]
+    pub receive_ephemeral: Option<bool>,
+
     #[serde(rename = "org.matrix.msc3202", skip_serializing_if = "Option::is_none")]
     pub msc3202: Option<bool>,
 }

--- a/src/bin/generate_registration.rs
+++ b/src/bin/generate_registration.rs
@@ -49,8 +49,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rate_limited: None,
         namespaces,
         protocols: vec![],
-        soru_ephemeral_events: None,
+        soru_ephemeral_events: Some(true),
         ephemeral_events: None,
+        receive_ephemeral: Some(true),
         msc3202: None,
     };
 

--- a/src/data_layer/mod.rs
+++ b/src/data_layer/mod.rs
@@ -10,12 +10,14 @@ pub mod data_layer {
     pub  use crate::data_layer::models::{
         LNBitsId, MatrixId2LNBitsId, NewMatrixId2LNBitsId,
         LnAddress, NewLnAddress, MatrixStore, NewMatrixStore,
+        DmRoom, NewDmRoom,
     };
     use crate::data_layer::schema;
 
     use schema::matrix_id_2_lnbits_id::dsl::*;
     use schema::ln_addresses::dsl as ln_addresses_dsl;
     use schema::matrix_store::dsl as matrix_store_dsl;
+    use schema::dm_rooms::dsl as dm_rooms_dsl;
 
     #[derive(Clone)]
     pub struct DataLayer {
@@ -93,6 +95,24 @@ pub mod data_layer {
                 .values(&new_store)
                 .execute(&mut connection)
                 .expect("Error saving matrix store");
+        }
+
+        pub fn dm_room_for_user(&self, matrix_id_: &str) -> Option<String> {
+            let mut connection = self.establish_connection();
+            dm_rooms_dsl::dm_rooms
+                .filter(dm_rooms_dsl::matrix_id.eq(matrix_id_))
+                .select(dm_rooms_dsl::room_id)
+                .first::<String>(&mut connection)
+                .ok()
+        }
+
+        pub fn save_dm_room(&self, matrix_id_: &str, room_id_: &str) {
+            let mut connection = self.establish_connection();
+            let record = NewDmRoom { matrix_id: matrix_id_, room_id: room_id_ };
+            diesel::replace_into(schema::dm_rooms::table)
+                .values(&record)
+                .execute(&mut connection)
+                .expect("Error saving dm room");
         }
     }
 }

--- a/src/data_layer/models.rs
+++ b/src/data_layer/models.rs
@@ -98,3 +98,19 @@ pub struct NewMatrixStore<'a> {
     pub state: &'a [u8],
     pub crypto: &'a [u8],
 }
+
+#[derive(Debug, Queryable, Identifiable, Selectable)]
+#[diesel(table_name = dm_rooms)]
+#[diesel(primary_key(matrix_id))]
+#[diesel(check_for_backend(Sqlite))]
+pub struct DmRoom {
+    pub matrix_id: String,
+    pub room_id: String,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = dm_rooms)]
+pub struct NewDmRoom<'a> {
+    pub matrix_id: &'a str,
+    pub room_id: &'a str,
+}

--- a/src/data_layer/schema.rs
+++ b/src/data_layer/schema.rs
@@ -26,3 +26,10 @@ diesel::table! {
         crypto -> Binary,
     }
 }
+
+diesel::table! {
+    dm_rooms (matrix_id) {
+        matrix_id -> Text,
+        room_id -> Text,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), SimpleError>  {
 
     let matrix_bot: Arc<MatrixBot> = Arc::new(MatrixBot::new(data_layer, ln_client, &config).await);
 
-    matrix_bot.init().await;
+    matrix_bot.clone().init().await;
     matrix_bot.sync().await.map_err(|e| SimpleError::new(format!("{:?}", e)))?;
 
     run_server(matrix_bot.clone(), config.registration.clone()).await;

--- a/src/matrix_bot/business_logic.rs
+++ b/src/matrix_bot/business_logic.rs
@@ -265,6 +265,7 @@ impl BusinessLogicContext {
                 format!("{} you received {} Sats from {}", recipient, amount, sender)
             };
             reply.receiver_message = Some(receiver_msg);
+            reply.receiver_id = Some(recipient.to_string());
         }
 
         Ok(reply)
@@ -355,7 +356,7 @@ impl BusinessLogicContext {
 
     async fn do_process_help(&self) -> Result<CommandReply, SimpleError> {
         log::info!("processing help command ..");
-        Ok(CommandReply::text_only(self.get_help_content().as_str()))
+        Ok(CommandReply::markdown(self.get_help_content().as_str()))
     }
 
     async fn do_process_party(&self) -> Result<CommandReply, SimpleError> {

--- a/src/matrix_bot/commands.rs
+++ b/src/matrix_bot/commands.rs
@@ -23,10 +23,12 @@ pub enum Command  {
 #[derive(Debug)]
 pub struct CommandReply {
     pub text: Option<String>,
+    pub markdown: bool,
     pub image: Option<Vec<u8>>,
     pub payment_hash: Option<String>,
     pub in_key: Option<String>,
     pub receiver_message: Option<String>,
+    pub receiver_id: Option<String>,
 }
 
 impl Command {
@@ -166,20 +168,36 @@ impl CommandReply {
     pub fn text_only(text: &str) -> CommandReply {
         CommandReply {
             text: Some(text.to_string()),
+            markdown: false,
             image: None,
             payment_hash: None,
             in_key: None,
             receiver_message: None,
+            receiver_id: None,
         }
     }
 
     pub fn new(text: &str, image: Vec<u8>) -> CommandReply {
         CommandReply {
             text: Some(text.to_string()),
+            markdown: false,
             image: Some(image),
             payment_hash: None,
             in_key: None,
             receiver_message: None,
+            receiver_id: None,
+        }
+    }
+
+    pub fn markdown(text: &str) -> CommandReply {
+        CommandReply {
+            text: Some(text.to_string()),
+            markdown: true,
+            image: None,
+            payment_hash: None,
+            in_key: None,
+            receiver_message: None,
+            receiver_id: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- upload device and one-time keys using new MatrixAsClient helpers
- call `process_outgoing_requests` when encrypting/decrypting and after receiving to-device messages
- initialise encryption helper with key upload on startup
- update README examples for new encrypt_text signature
- properly send outgoing encryption requests and mark them as sent
- **process all outstanding key requests and retry failures**
- document the keys API endpoints needed for end-to-end encryption
- refresh bot presence periodically
- encode the user ID when setting presence
- pass the device ID when uploading keys

## Testing
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685edfcde3e8832e96ddad2bd4ab8062