### PR TITLE
Implement tokio background sync for encryption

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -124,10 +124,9 @@ used for creating lightning addresses without the bearer token:
 ```
 
 Encrypted client keys are automatically saved in the database's `matrix_store` table.
-At startup the bot performs a client login using the application service token and stores
-the returned `access_token` together with the fixed device ID `ASDEVICE` in the
-database. All Matrix Client-Server API calls then use this token so no device
-configuration is required.
+At startup the bot registers a device using [MSC4190](https://github.com/matrix-org/matrix-spec-proposals/pull/4190)
+and thereafter authenticates all Client-Server API requests solely with the application service token.
+No interactive login or access token handling is performed by the bot itself.
 If `--avatar-path` is set, the bot sets its avatar URL to this `mxc` link at startup
 using `PUT /_matrix/client/v3/profile/{userId}/avatar_url`.
 
@@ -170,10 +169,6 @@ whether that user is registered.
 Transactions use the standard [push events](https://spec.matrix.org/latest/application-service-api/#put_matrixappv1transactionstxnid)
 format so the JSON body may contain `events`, `ephemeral`, `de.sorunome.msc2409.send_to_device`, and other optional fields.
 
-For end-to-end encryption the bot relies on the Matrix Client-Server API
-endpoints `POST /_matrix/client/v3/keys/upload`, `POST /_matrix/client/v3/keys/query`
-and `POST /_matrix/client/v3/keys/claim`. These requests are issued automatically
-whenever new keys need to be uploaded or claimed.
 
 The bot checks each room for the `m.room.encryption` state event before sending a message. Messages to encrypted rooms are locally encrypted, while unencrypted rooms receive plain text.
 Example code:

--- a/migrations/2025-06-28-000004_client_auth/down.sql
+++ b/migrations/2025-06-28-000004_client_auth/down.sql
@@ -1,1 +1,0 @@
-DROP TABLE client_auth;

--- a/migrations/2025-06-28-000004_client_auth/up.sql
+++ b/migrations/2025-06-28-000004_client_auth/up.sql
@@ -1,6 +1,0 @@
-CREATE TABLE client_auth (
-    id INTEGER PRIMARY KEY CHECK (id = 1),
-    access_token TEXT NOT NULL,
-    device_id TEXT NOT NULL
-);
-INSERT INTO client_auth (id, access_token, device_id) VALUES (1, '', 'ASDEVICE');

--- a/src/application_service/application_service.rs
+++ b/src/application_service/application_service.rs
@@ -103,6 +103,10 @@ struct TransactionRequest {
     /// To-device messages (ignored)
     #[serde(default, rename = "de.sorunome.msc2409.send_to_device")]
     pub send_to_device: Vec<serde_json::Value>,
+    #[serde(default, rename = "org.matrix.msc4190.device_lists")]
+    pub device_lists: Option<serde_json::Value>,
+    #[serde(default, rename = "org.matrix.msc4190.one_time_key_counts")]
+    pub one_time_key_counts: Option<serde_json::Value>,
 }
 
 async fn transactions_handler(
@@ -159,7 +163,15 @@ async fn transactions_handler(
         state_guard.txn_idc_cache.mark_processed(txn_id);
     }
 
-    bot.clone().handle_transaction_events(req.events, req.send_to_device).await;
+    bot
+        .clone()
+        .handle_transaction_events(
+            req.events,
+            req.send_to_device,
+            req.device_lists,
+            req.one_time_key_counts,
+        )
+        .await;
     Ok(warp::reply::with_status(
         warp::reply::json(&serde_json::json!({})),
         StatusCode::OK,

--- a/src/as_client.rs
+++ b/src/as_client.rs
@@ -1,7 +1,5 @@
 use reqwest::{Client, StatusCode};
 use serde_json::json;
-use ruma::api::client::keys::{claim_keys, get_keys, upload_keys};
-use ruma::api::IncomingResponse;
 use crate::config::config::Config;
 use crate::data_layer::data_layer::DataLayer;
 use std::collections::HashMap;
@@ -18,7 +16,6 @@ pub struct MatrixAsClient {
     homeserver: String,
     user_id: String,
     as_token: String,
-    access_token: Option<String>,
     http: Client,
     dm_rooms: Arc<Mutex<HashMap<String, String>>>,
     data_layer: DataLayer,
@@ -39,7 +36,6 @@ impl MatrixAsClient {
                     .unwrap(),
             ),
             as_token: config.registration.app_token.clone(),
-            access_token: None,
             http: Client::new(),
             dm_rooms: Arc::new(Mutex::new(HashMap::new())),
             data_layer,
@@ -47,73 +43,25 @@ impl MatrixAsClient {
         }
     }
 
-    pub fn load_auth(&mut self) {
-        if let Some(record) = self.data_layer.load_client_auth() {
-            self.access_token = Some(record.access_token);
-            self.device_id = record.device_id;
-        }
-    }
-
-    pub fn has_access_token(&self) -> bool {
-        self.access_token.is_some()
-    }
-
-    async fn save_auth(&self) {
-        if let Some(token) = &self.access_token {
-            self.data_layer
-                .save_client_auth(token, &self.device_id);
-        }
-    }
-
-    pub async fn login(&mut self) {
-        let localpart = self
-            .user_id
-            .split(':')
-            .next()
-            .unwrap()
-            .trim_start_matches('@');
+    pub async fn create_device(&self) {
         let url = format!(
-            "{}/_matrix/client/v3/login?access_token={}",
-            self.homeserver, self.as_token
+            "{}/_matrix/client/v1/admin/create_device",
+            self.homeserver
         );
         let body = json!({
-            "type": "m.login.application_service",
-            "identifier": { "type": "m.id.user", "user": localpart },
-            "device_id": self.device_id,
-            "initial_device_display_name": "Lightning Tip Bot"
+            "user_id": self.user_id,
+            "device_id": DEVICE_ID,
+            "display_name": "Lightning Tip Bot"
         });
-        if let Ok(resp) = self.http.post(url).json(&body).send().await {
-            if resp.status() == StatusCode::OK {
-                if let Ok(json) = resp.json::<serde_json::Value>().await {
-                    if let Some(access) = json.get("access_token").and_then(|v| v.as_str()) {
-                        self.access_token = Some(access.to_owned());
-                    }
-                    if let Some(dev) = json.get("device_id").and_then(|v| v.as_str()) {
-                        self.device_id = dev.to_owned();
-                    }
-                    self.save_auth().await;
-                }
-            }
-        }
+        let _ = self
+            .http
+            .post(url)
+            .query(&[("access_token", self.as_token.clone())])
+            .json(&body)
+            .send()
+            .await;
     }
 
-    pub async fn ensure_valid_token(&mut self) {
-        if let Some(token) = &self.access_token {
-            let url = format!(
-                "{}/_matrix/client/v3/account/whoami",
-                self.homeserver
-            );
-            let resp = self.http.get(url).bearer_auth(token).send().await;
-            if resp
-                .map(|r| r.status() == StatusCode::UNAUTHORIZED)
-                .unwrap_or(true)
-            {
-                log::warn!("Stored access token invalid, re-logging in");
-                self.access_token = None;
-                self.login().await;
-            }
-        }
-    }
 
     pub async fn set_presence(&self, presence: &str, status_msg: &str) {
         let url = format!(
@@ -166,7 +114,7 @@ impl MatrixAsClient {
 
     fn auth_query(&self) -> Vec<(&str, String)> {
         vec![
-            ("access_token", self.access_token.clone().unwrap_or_default()),
+            ("access_token", self.as_token.clone()),
             ("device_id", self.device_id.clone()),
         ]
     }
@@ -385,78 +333,4 @@ impl MatrixAsClient {
         }
     }
 
-    pub async fn keys_upload(
-        &self,
-        request: upload_keys::v3::Request,
-    ) -> Option<upload_keys::v3::Response> {
-        use ruma::api::{OutgoingRequest, SendAccessToken, MatrixVersion};
-        let token = self.access_token.as_deref()?;
-        let http_req = request
-            .try_into_http_request::<Vec<u8>>(
-                &self.homeserver,
-                SendAccessToken::IfRequired(token),
-                &[MatrixVersion::V1_1],
-            )
-            .ok()?;
-
-        let (mut parts, body) = http_req.into_parts();
-        let mut uri = parts.uri.to_string();
-        let sep = if uri.contains('?') { '&' } else { '?' };
-        uri.push_str(&format!("{sep}device_id={}", DEVICE_ID));
-        parts.uri = uri.parse().ok()?;
-        let http_req = ruma::exports::http::Request::from_parts(parts, body);
-
-        let response = self.send_request(http_req).await?;
-        upload_keys::v3::Response::try_from_http_response(response).ok()
-    }
-
-    pub async fn keys_query(
-        &self,
-        request: get_keys::v3::Request,
-    ) -> Option<get_keys::v3::Response> {
-        use ruma::api::{OutgoingRequest, SendAccessToken, MatrixVersion};
-        let token = self.access_token.as_deref()?;
-        let http_req = request
-            .try_into_http_request::<Vec<u8>>(
-                &self.homeserver,
-                SendAccessToken::IfRequired(token),
-                &[MatrixVersion::V1_1],
-            )
-            .ok()?;
-
-        let (mut parts, body) = http_req.into_parts();
-        let mut uri = parts.uri.to_string();
-        let sep = if uri.contains('?') { '&' } else { '?' };
-        uri.push_str(&format!("{sep}device_id={}", DEVICE_ID));
-        parts.uri = uri.parse().ok()?;
-        let http_req = ruma::exports::http::Request::from_parts(parts, body);
-
-        let response = self.send_request(http_req).await?;
-        get_keys::v3::Response::try_from_http_response(response).ok()
-    }
-
-    pub async fn keys_claim(
-        &self,
-        request: claim_keys::v3::Request,
-    ) -> Option<claim_keys::v3::Response> {
-        use ruma::api::{OutgoingRequest, SendAccessToken, MatrixVersion};
-        let token = self.access_token.as_deref()?;
-        let http_req = request
-            .try_into_http_request::<Vec<u8>>(
-                &self.homeserver,
-                SendAccessToken::IfRequired(token),
-                &[MatrixVersion::V1_1],
-            )
-            .ok()?;
-
-        let (mut parts, body) = http_req.into_parts();
-        let mut uri = parts.uri.to_string();
-        let sep = if uri.contains('?') { '&' } else { '?' };
-        uri.push_str(&format!("{sep}device_id={}", DEVICE_ID));
-        parts.uri = uri.parse().ok()?;
-        let http_req = ruma::exports::http::Request::from_parts(parts, body);
-
-        let response = self.send_request(http_req).await?;
-        claim_keys::v3::Response::try_from_http_response(response).ok()
-    }
 }

--- a/src/data_layer/mod.rs
+++ b/src/data_layer/mod.rs
@@ -10,7 +10,7 @@ pub mod data_layer {
     pub  use crate::data_layer::models::{
         LNBitsId, MatrixId2LNBitsId, NewMatrixId2LNBitsId,
         LnAddress, NewLnAddress, MatrixStore, NewMatrixStore,
-        NewDmRoom, ClientAuth, NewClientAuth,
+        NewDmRoom,
     };
     use crate::data_layer::schema;
 
@@ -18,7 +18,6 @@ pub mod data_layer {
     use schema::ln_addresses::dsl as ln_addresses_dsl;
     use schema::matrix_store::dsl as matrix_store_dsl;
     use schema::dm_rooms::dsl as dm_rooms_dsl;
-    use schema::client_auth::dsl as client_auth_dsl;
 
     #[derive(Clone)]
     pub struct DataLayer {
@@ -116,24 +115,6 @@ pub mod data_layer {
                 .expect("Error saving dm room");
         }
 
-        pub fn load_client_auth(&self) -> Option<ClientAuth> {
-            let mut connection = self.establish_connection();
-            client_auth_dsl::client_auth
-                .filter(client_auth_dsl::id.eq(1))
-                .select(ClientAuth::as_select())
-                .load::<ClientAuth>(&mut connection)
-                .ok()
-                .and_then(|mut v| v.pop())
-        }
-
-        pub fn save_client_auth(&self, access_token: &str, device_id: &str) {
-            let mut connection = self.establish_connection();
-            let record = NewClientAuth { id: 1, access_token, device_id };
-            diesel::replace_into(schema::client_auth::table)
-                .values(&record)
-                .execute(&mut connection)
-                .expect("Error saving client auth");
-        }
     }
 }
 

--- a/src/data_layer/models.rs
+++ b/src/data_layer/models.rs
@@ -106,19 +106,3 @@ pub struct NewDmRoom<'a> {
     pub room_id: &'a str,
 }
 
-#[derive(Debug, Queryable, Identifiable, Selectable)]
-#[diesel(table_name = client_auth)]
-#[diesel(check_for_backend(Sqlite))]
-pub struct ClientAuth {
-    pub id: Option<i32>,
-    pub access_token: String,
-    pub device_id: String,
-}
-
-#[derive(Insertable)]
-#[diesel(table_name = client_auth)]
-pub struct NewClientAuth<'a> {
-    pub id: i32,
-    pub access_token: &'a str,
-    pub device_id: &'a str,
-}

--- a/src/data_layer/schema.rs
+++ b/src/data_layer/schema.rs
@@ -1,14 +1,11 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    matrix_id_2_lnbits_id (matrix_id) {
-        matrix_id -> Text,
-        lnbits_id -> Text,
-        lnbits_admin -> Text,
-        date_created -> Text,
+    dm_rooms (matrix_id) {
+        matrix_id -> Nullable<Text>,
+        room_id -> Text,
     }
 }
-
 
 diesel::table! {
     ln_addresses (id) {
@@ -21,6 +18,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    matrix_id_2_lnbits_id (matrix_id) {
+        matrix_id -> Text,
+        lnbits_id -> Text,
+        lnbits_admin -> Text,
+        date_created -> Text,
+    }
+}
+
+diesel::table! {
     matrix_store (id) {
         id -> Nullable<Integer>,
         state -> Binary,
@@ -28,9 +34,9 @@ diesel::table! {
     }
 }
 
-diesel::table! {
-    dm_rooms (matrix_id) {
-        matrix_id -> Text,
-        room_id -> Text,
-    }
-}
+diesel::allow_tables_to_appear_in_same_query!(
+    dm_rooms,
+    ln_addresses,
+    matrix_id_2_lnbits_id,
+    matrix_store,
+);

--- a/src/data_layer/schema.rs
+++ b/src/data_layer/schema.rs
@@ -9,13 +9,6 @@ diesel::table! {
     }
 }
 
-diesel::table! {
-    client_auth (id) {
-        id -> Nullable<Integer>,
-        access_token -> Text,
-        device_id -> Text,
-    }
-}
 
 diesel::table! {
     ln_addresses (id) {

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -34,6 +34,7 @@ impl MatrixBot {
         let ctx = BusinessLogicContext::new(lnbits_client, data_layer.clone(), config);
         let mut as_client = MatrixAsClient::new(config, data_layer.clone());
         as_client.load_auth();
+        as_client.ensure_valid_token().await;
         if !as_client.has_access_token() {
             for attempt in 1..=3 {
                 as_client.login().await;

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -15,6 +15,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static BOT_CREATED: AtomicBool = AtomicBool::new(false);
 
 pub struct MatrixBot {
     pub business_logic_context: BusinessLogicContext,
@@ -25,6 +28,9 @@ pub struct MatrixBot {
 
 impl MatrixBot {
     pub async fn new(data_layer: DataLayer, lnbits_client: LNBitsClient, config: &Config) -> Self {
+        if BOT_CREATED.swap(true, Ordering::SeqCst) {
+            panic!("MatrixBot initialized multiple times");
+        }
         let ctx = BusinessLogicContext::new(lnbits_client, data_layer.clone(), config);
         let mut as_client = MatrixAsClient::new(config, data_layer.clone());
         as_client.load_auth();


### PR DESCRIPTION
## Summary
- spawn a background task that continuously syncs encryption keys
- rework `EncryptionHelper` APIs to run without explicit client
- update `MatrixBot` to own `Arc<EncryptionHelper>` and start sync loop
- adjust message helpers to use new encryption API
