### PR TITLE
Validate access token before starting sync loop

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -124,10 +124,9 @@ used for creating lightning addresses without the bearer token:
 ```
 
 Encrypted client keys are automatically saved in the database's `matrix_store` table.
-At startup the bot performs a client login using the application service token and stores
-the returned `access_token` together with the fixed device ID `ASDEVICE` in the
-database. All Matrix Client-Server API calls then use this token so no device
-configuration is required.
+At startup the bot registers a device using [MSC4190](https://github.com/matrix-org/matrix-spec-proposals/pull/4190).
+All Matrix Client-Server API calls authenticate with the application service token and the
+`user_id`/`device_id` query parameters, no regular login or access token storage is required.
 If `--avatar-path` is set, the bot sets its avatar URL to this `mxc` link at startup
 using `PUT /_matrix/client/v3/profile/{userId}/avatar_url`.
 
@@ -170,10 +169,6 @@ whether that user is registered.
 Transactions use the standard [push events](https://spec.matrix.org/latest/application-service-api/#put_matrixappv1transactionstxnid)
 format so the JSON body may contain `events`, `ephemeral`, `de.sorunome.msc2409.send_to_device`, and other optional fields.
 
-For end-to-end encryption the bot relies on the Matrix Client-Server API
-endpoints `POST /_matrix/client/v3/keys/upload`, `POST /_matrix/client/v3/keys/query`
-and `POST /_matrix/client/v3/keys/claim`. These requests are issued automatically
-whenever new keys need to be uploaded or claimed.
 
 The bot checks each room for the `m.room.encryption` state event before sending a message. Messages to encrypted rooms are locally encrypted, while unencrypted rooms receive plain text.
 Example code:

--- a/migrations/2025-06-28-000004_client_auth/down.sql
+++ b/migrations/2025-06-28-000004_client_auth/down.sql
@@ -1,1 +1,0 @@
-DROP TABLE client_auth;

--- a/migrations/2025-06-28-000004_client_auth/up.sql
+++ b/migrations/2025-06-28-000004_client_auth/up.sql
@@ -1,6 +1,0 @@
-CREATE TABLE client_auth (
-    id INTEGER PRIMARY KEY CHECK (id = 1),
-    access_token TEXT NOT NULL,
-    device_id TEXT NOT NULL
-);
-INSERT INTO client_auth (id, access_token, device_id) VALUES (1, '', 'ASDEVICE');

--- a/src/application_service/application_service.rs
+++ b/src/application_service/application_service.rs
@@ -103,6 +103,10 @@ struct TransactionRequest {
     /// To-device messages (ignored)
     #[serde(default, rename = "de.sorunome.msc2409.send_to_device")]
     pub send_to_device: Vec<serde_json::Value>,
+    #[serde(default, rename = "org.matrix.msc4190.device_lists")]
+    pub device_lists: Option<serde_json::Value>,
+    #[serde(default, rename = "org.matrix.msc4190.one_time_key_counts")]
+    pub one_time_key_counts: Option<serde_json::Value>,
 }
 
 async fn transactions_handler(
@@ -159,7 +163,15 @@ async fn transactions_handler(
         state_guard.txn_idc_cache.mark_processed(txn_id);
     }
 
-    bot.clone().handle_transaction_events(req.events, req.send_to_device).await;
+    bot
+        .clone()
+        .handle_transaction_events(
+            req.events,
+            req.send_to_device,
+            req.device_lists,
+            req.one_time_key_counts,
+        )
+        .await;
     Ok(warp::reply::with_status(
         warp::reply::json(&serde_json::json!({})),
         StatusCode::OK,

--- a/src/as_client.rs
+++ b/src/as_client.rs
@@ -18,11 +18,9 @@ pub struct MatrixAsClient {
     homeserver: String,
     user_id: String,
     as_token: String,
-    access_token: Option<String>,
     http: Client,
     dm_rooms: Arc<Mutex<HashMap<String, String>>>,
     data_layer: DataLayer,
-    #[allow(dead_code)]
     device_id: String,
 }
 
@@ -39,7 +37,6 @@ impl MatrixAsClient {
                     .unwrap(),
             ),
             as_token: config.registration.app_token.clone(),
-            access_token: None,
             http: Client::new(),
             dm_rooms: Arc::new(Mutex::new(HashMap::new())),
             data_layer,
@@ -47,55 +44,24 @@ impl MatrixAsClient {
         }
     }
 
-    pub fn load_auth(&mut self) {
-        if let Some(record) = self.data_layer.load_client_auth() {
-            self.access_token = Some(record.access_token);
-            self.device_id = record.device_id;
-        }
-    }
-
-    pub fn has_access_token(&self) -> bool {
-        self.access_token.is_some()
-    }
-
-    async fn save_auth(&self) {
-        if let Some(token) = &self.access_token {
-            self.data_layer
-                .save_client_auth(token, &self.device_id);
-        }
-    }
-
-    pub async fn login(&mut self) {
-        let localpart = self
-            .user_id
-            .split(':')
-            .next()
-            .unwrap()
-            .trim_start_matches('@');
+    pub async fn create_device_msc4190(&self) {
         let url = format!(
-            "{}/_matrix/client/v3/login?access_token={}",
-            self.homeserver, self.as_token
+            "{}/_matrix/client/v3/devices/{}",
+            self.homeserver,
+            DEVICE_ID
         );
         let body = json!({
-            "type": "m.login.application_service",
-            "identifier": { "type": "m.id.user", "user": localpart },
-            "device_id": self.device_id,
-            "initial_device_display_name": "Lightning Tip Bot"
+            "display_name": "Lightning Tip Bot"
         });
-        if let Ok(resp) = self.http.post(url).json(&body).send().await {
-            if resp.status() == StatusCode::OK {
-                if let Ok(json) = resp.json::<serde_json::Value>().await {
-                    if let Some(access) = json.get("access_token").and_then(|v| v.as_str()) {
-                        self.access_token = Some(access.to_owned());
-                    }
-                    if let Some(dev) = json.get("device_id").and_then(|v| v.as_str()) {
-                        self.device_id = dev.to_owned();
-                    }
-                    self.save_auth().await;
-                }
-            }
-        }
+        let _ = self
+            .http
+            .put(url)
+            .query(&self.auth_query())
+            .json(&body)
+            .send()
+            .await;
     }
+
 
     pub async fn set_presence(&self, presence: &str, status_msg: &str) {
         let url = format!(
@@ -148,8 +114,10 @@ impl MatrixAsClient {
 
     fn auth_query(&self) -> Vec<(&str, String)> {
         vec![
-            ("access_token", self.access_token.clone().unwrap_or_default()),
+            ("access_token", self.as_token.clone()),
+            ("user_id", self.user_id.clone()),
             ("device_id", self.device_id.clone()),
+            ("org.matrix.msc3202.device_id", self.device_id.clone()),
         ]
     }
 
@@ -361,30 +329,26 @@ impl MatrixAsClient {
         room_id
     }
 
-    pub async fn send_dm(&self, user_id: &str, body: &str) {
-        if let Some(room_id) = self.create_dm_room(user_id).await {
-            self.send_text(&room_id, body).await;
-        }
-    }
-
     pub async fn keys_upload(
         &self,
         request: upload_keys::v3::Request,
     ) -> Option<upload_keys::v3::Response> {
         use ruma::api::{OutgoingRequest, SendAccessToken, MatrixVersion};
-        let token = self.access_token.as_deref()?;
         let http_req = request
             .try_into_http_request::<Vec<u8>>(
                 &self.homeserver,
-                SendAccessToken::IfRequired(token),
+                SendAccessToken::None,
                 &[MatrixVersion::V1_1],
             )
             .ok()?;
 
         let (mut parts, body) = http_req.into_parts();
         let mut uri = parts.uri.to_string();
-        let sep = if uri.contains('?') { '&' } else { '?' };
-        uri.push_str(&format!("{sep}device_id={}", DEVICE_ID));
+        let mut sep = if uri.contains('?') { '&' } else { '?' };
+        for (k, v) in self.auth_query() {
+            uri.push_str(&format!("{sep}{k}={}", encode(&v)));
+            sep = '&';
+        }
         parts.uri = uri.parse().ok()?;
         let http_req = ruma::exports::http::Request::from_parts(parts, body);
 
@@ -397,19 +361,21 @@ impl MatrixAsClient {
         request: get_keys::v3::Request,
     ) -> Option<get_keys::v3::Response> {
         use ruma::api::{OutgoingRequest, SendAccessToken, MatrixVersion};
-        let token = self.access_token.as_deref()?;
         let http_req = request
             .try_into_http_request::<Vec<u8>>(
                 &self.homeserver,
-                SendAccessToken::IfRequired(token),
+                SendAccessToken::None,
                 &[MatrixVersion::V1_1],
             )
             .ok()?;
 
         let (mut parts, body) = http_req.into_parts();
         let mut uri = parts.uri.to_string();
-        let sep = if uri.contains('?') { '&' } else { '?' };
-        uri.push_str(&format!("{sep}device_id={}", DEVICE_ID));
+        let mut sep = if uri.contains('?') { '&' } else { '?' };
+        for (k, v) in self.auth_query() {
+            uri.push_str(&format!("{sep}{k}={}", encode(&v)));
+            sep = '&';
+        }
         parts.uri = uri.parse().ok()?;
         let http_req = ruma::exports::http::Request::from_parts(parts, body);
 
@@ -422,23 +388,32 @@ impl MatrixAsClient {
         request: claim_keys::v3::Request,
     ) -> Option<claim_keys::v3::Response> {
         use ruma::api::{OutgoingRequest, SendAccessToken, MatrixVersion};
-        let token = self.access_token.as_deref()?;
         let http_req = request
             .try_into_http_request::<Vec<u8>>(
                 &self.homeserver,
-                SendAccessToken::IfRequired(token),
+                SendAccessToken::None,
                 &[MatrixVersion::V1_1],
             )
             .ok()?;
 
         let (mut parts, body) = http_req.into_parts();
         let mut uri = parts.uri.to_string();
-        let sep = if uri.contains('?') { '&' } else { '?' };
-        uri.push_str(&format!("{sep}device_id={}", DEVICE_ID));
+        let mut sep = if uri.contains('?') { '&' } else { '?' };
+        for (k, v) in self.auth_query() {
+            uri.push_str(&format!("{sep}{k}={}", encode(&v)));
+            sep = '&';
+        }
         parts.uri = uri.parse().ok()?;
         let http_req = ruma::exports::http::Request::from_parts(parts, body);
 
         let response = self.send_request(http_req).await?;
         claim_keys::v3::Response::try_from_http_response(response).ok()
     }
+
+    pub async fn send_dm(&self, user_id: &str, body: &str) {
+        if let Some(room_id) = self.create_dm_room(user_id).await {
+            self.send_text(&room_id, body).await;
+        }
+    }
+
 }

--- a/src/data_layer/mod.rs
+++ b/src/data_layer/mod.rs
@@ -10,7 +10,7 @@ pub mod data_layer {
     pub  use crate::data_layer::models::{
         LNBitsId, MatrixId2LNBitsId, NewMatrixId2LNBitsId,
         LnAddress, NewLnAddress, MatrixStore, NewMatrixStore,
-        NewDmRoom, ClientAuth, NewClientAuth,
+        NewDmRoom,
     };
     use crate::data_layer::schema;
 
@@ -18,7 +18,6 @@ pub mod data_layer {
     use schema::ln_addresses::dsl as ln_addresses_dsl;
     use schema::matrix_store::dsl as matrix_store_dsl;
     use schema::dm_rooms::dsl as dm_rooms_dsl;
-    use schema::client_auth::dsl as client_auth_dsl;
 
     #[derive(Clone)]
     pub struct DataLayer {
@@ -116,24 +115,7 @@ pub mod data_layer {
                 .expect("Error saving dm room");
         }
 
-        pub fn load_client_auth(&self) -> Option<ClientAuth> {
-            let mut connection = self.establish_connection();
-            client_auth_dsl::client_auth
-                .filter(client_auth_dsl::id.eq(1))
-                .select(ClientAuth::as_select())
-                .load::<ClientAuth>(&mut connection)
-                .ok()
-                .and_then(|mut v| v.pop())
-        }
 
-        pub fn save_client_auth(&self, access_token: &str, device_id: &str) {
-            let mut connection = self.establish_connection();
-            let record = NewClientAuth { id: 1, access_token, device_id };
-            diesel::replace_into(schema::client_auth::table)
-                .values(&record)
-                .execute(&mut connection)
-                .expect("Error saving client auth");
-        }
     }
 }
 

--- a/src/data_layer/models.rs
+++ b/src/data_layer/models.rs
@@ -106,19 +106,4 @@ pub struct NewDmRoom<'a> {
     pub room_id: &'a str,
 }
 
-#[derive(Debug, Queryable, Identifiable, Selectable)]
-#[diesel(table_name = client_auth)]
-#[diesel(check_for_backend(Sqlite))]
-pub struct ClientAuth {
-    pub id: Option<i32>,
-    pub access_token: String,
-    pub device_id: String,
-}
 
-#[derive(Insertable)]
-#[diesel(table_name = client_auth)]
-pub struct NewClientAuth<'a> {
-    pub id: i32,
-    pub access_token: &'a str,
-    pub device_id: &'a str,
-}

--- a/src/data_layer/schema.rs
+++ b/src/data_layer/schema.rs
@@ -10,14 +10,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    client_auth (id) {
-        id -> Nullable<Integer>,
-        access_token -> Text,
-        device_id -> Text,
-    }
-}
-
-diesel::table! {
     ln_addresses (id) {
         id -> Nullable<Integer>,
         matrix_id -> Text,

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,5 +1,7 @@
 use matrix_sdk_crypto::OlmMachine;
 use std::pin::Pin;
+use std::sync::Arc;
+use tokio::time::Duration;
 use matrix_sdk_sqlite::{SqliteCryptoStore, STATE_STORE_DATABASE_NAME};
 use ruma::{OwnedDeviceId, OwnedRoomId, OwnedUserId};
 use tempfile::TempDir;
@@ -56,7 +58,7 @@ impl EncryptionHelper {
         EncryptionHelper { machine, data_layer: data_layer.clone(), dir }
     }
 
-    pub async fn encrypt_text(&self, room_id: &str, body: &str, client: &crate::as_client::MatrixAsClient) -> (String, serde_json::Value) {
+    pub async fn encrypt_text(&self, room_id: &str, body: &str) -> (String, serde_json::Value) {
         use ruma::events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent};
 
         let room_id: OwnedRoomId = room_id.parse().unwrap();
@@ -74,7 +76,6 @@ impl EncryptionHelper {
             log::error!("Failed to save crypto store: {}", e);
         }
 
-        self.process_outgoing_requests(client).await;
 
         // Persist store
         let state = fs::read(self.dir.path().join(STATE_STORE_DATABASE_NAME))
@@ -91,7 +92,7 @@ impl EncryptionHelper {
         )
     }
 
-    pub async fn encrypt_html(&self, room_id: &str, body: &str, html: &str, client: &crate::as_client::MatrixAsClient) -> (String, serde_json::Value) {
+    pub async fn encrypt_html(&self, room_id: &str, body: &str, html: &str) -> (String, serde_json::Value) {
         use ruma::events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent};
 
         let room_id: OwnedRoomId = room_id.parse().unwrap();
@@ -109,7 +110,6 @@ impl EncryptionHelper {
             log::error!("Failed to save crypto store: {}", e);
         }
 
-        self.process_outgoing_requests(client).await;
 
         // Persist store
         let state = fs::read(self.dir.path().join(STATE_STORE_DATABASE_NAME))
@@ -126,7 +126,7 @@ impl EncryptionHelper {
         )
     }
 
-    pub async fn receive_to_device(&self, events: Vec<serde_json::Value>, client: &crate::as_client::MatrixAsClient) {
+    pub async fn receive_to_device(&self, events: Vec<serde_json::Value>) {
         use matrix_sdk_crypto::{EncryptionSyncChanges};
         use ruma::{api::client::sync::sync_events::DeviceLists, serde::Raw, OneTimeKeyAlgorithm, UInt, events::AnyToDeviceEvent};
         use std::collections::BTreeMap;
@@ -151,7 +151,6 @@ impl EncryptionHelper {
             if let Err(e) = self.machine.store().save().await {
                 log::error!("Failed to save crypto store: {}", e);
             }
-            self.process_outgoing_requests(client).await;
         }
 
         let state = fs::read(self.dir.path().join(STATE_STORE_DATABASE_NAME))
@@ -163,7 +162,79 @@ impl EncryptionHelper {
         self.data_layer.save_matrix_store(&state, &crypto);
     }
 
-    pub async fn decrypt_event(&self, room_id: &str, event: &serde_json::Value, client: &crate::as_client::MatrixAsClient) -> Option<String> {
+    pub async fn receive_device_lists(&self, lists: serde_json::Value) {
+        use matrix_sdk_crypto::EncryptionSyncChanges;
+        use ruma::{api::client::sync::sync_events::DeviceLists, OneTimeKeyAlgorithm, UInt};
+        use std::collections::BTreeMap;
+
+        let device_lists: DeviceLists = serde_json::from_value(lists).unwrap_or_else(|_| DeviceLists::new());
+        let counts = BTreeMap::<OneTimeKeyAlgorithm, UInt>::new();
+
+        let changes = EncryptionSyncChanges {
+            to_device_events: Vec::new(),
+            changed_devices: &device_lists,
+            one_time_keys_counts: &counts,
+            unused_fallback_keys: None,
+            next_batch_token: None,
+        };
+
+        if let Err(e) = self.machine.receive_sync_changes(changes).await {
+            log::error!("Error processing device lists: {}", e);
+        }
+        if let Err(e) = self.machine.store().save().await {
+            log::error!("Failed to save crypto store: {}", e);
+        }
+
+        let state = fs::read(self.dir.path().join(STATE_STORE_DATABASE_NAME))
+            .await
+            .unwrap_or_default();
+        let crypto = fs::read(self.dir.path().join("matrix-sdk-crypto.sqlite3"))
+            .await
+            .unwrap_or_default();
+        self.data_layer.save_matrix_store(&state, &crypto);
+    }
+
+    pub async fn receive_otk_counts(&self, counts_json: serde_json::Value) {
+        use matrix_sdk_crypto::EncryptionSyncChanges;
+        use ruma::{api::client::sync::sync_events::DeviceLists, OneTimeKeyAlgorithm, UInt};
+        use std::collections::BTreeMap;
+
+        let mut counts = BTreeMap::<OneTimeKeyAlgorithm, UInt>::new();
+        if let Some(map) = counts_json.as_object() {
+            for (k, v) in map {
+                if let Some(num) = v.as_u64() {
+                    let alg = OneTimeKeyAlgorithm::from(k.as_str());
+                    counts.insert(alg, UInt::from(num as u32));
+                }
+            }
+        }
+        let device_lists = DeviceLists::new();
+
+        let changes = EncryptionSyncChanges {
+            to_device_events: Vec::new(),
+            changed_devices: &device_lists,
+            one_time_keys_counts: &counts,
+            unused_fallback_keys: None,
+            next_batch_token: None,
+        };
+
+        if let Err(e) = self.machine.receive_sync_changes(changes).await {
+            log::error!("Error processing one-time key counts: {}", e);
+        }
+        if let Err(e) = self.machine.store().save().await {
+            log::error!("Failed to save crypto store: {}", e);
+        }
+
+        let state = fs::read(self.dir.path().join(STATE_STORE_DATABASE_NAME))
+            .await
+            .unwrap_or_default();
+        let crypto = fs::read(self.dir.path().join("matrix-sdk-crypto.sqlite3"))
+            .await
+            .unwrap_or_default();
+        self.data_layer.save_matrix_store(&state, &crypto);
+    }
+
+    pub async fn decrypt_event(&self, room_id: &str, event: &serde_json::Value) -> Option<String> {
         use matrix_sdk_crypto::{DecryptionSettings, TrustRequirement};
         use matrix_sdk_crypto::types::events::room::encrypted::EncryptedEvent;
         use ruma::{serde::Raw, events::{AnyMessageLikeEvent, MessageLikeEvent, room::message::MessageType}};
@@ -171,17 +242,33 @@ impl EncryptionHelper {
         let raw: Raw<EncryptedEvent> = serde_json::value::to_raw_value(event).ok().map(Raw::from_json)?;
         let room_id: OwnedRoomId = room_id.parse().ok()?;
         let settings = DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
-        let decrypted = self
+        let decrypted = match self
             .machine
             .decrypt_room_event(&raw, &room_id, &settings)
             .await
-            .ok()?;
+        {
+            Ok(ev) => ev,
+            Err(e) => {
+                log::warn!("Failed to decrypt event: {}", e);
+                let _ = self.machine.request_room_key(&raw, &room_id).await;
+                if let Err(e) = self.machine.store().save().await {
+                    log::error!("Failed to save crypto store: {}", e);
+                }
+                let state = fs::read(self.dir.path().join(STATE_STORE_DATABASE_NAME))
+                    .await
+                    .unwrap_or_default();
+                let crypto = fs::read(self.dir.path().join("matrix-sdk-crypto.sqlite3"))
+                    .await
+                    .unwrap_or_default();
+                self.data_layer.save_matrix_store(&state, &crypto);
+                return None;
+            }
+        };
 
         if let Err(e) = self.machine.store().save().await {
             log::error!("Failed to save crypto store: {}", e);
         }
 
-        self.process_outgoing_requests(client).await;
 
         let state = fs::read(self.dir.path().join(STATE_STORE_DATABASE_NAME))
             .await
@@ -200,82 +287,69 @@ impl EncryptionHelper {
         None
     }
 
-    pub async fn process_outgoing_requests(&self, client: &crate::as_client::MatrixAsClient) {
+    pub async fn process_outgoing_requests(&self, client: &crate::as_client::MatrixAsClient) -> bool {
         use matrix_sdk_crypto::types::requests::AnyOutgoingRequest;
 
-        loop {
-            let requests = match self.machine.outgoing_requests().await {
-                Ok(r) => r,
-                Err(e) => {
-                    log::error!("Failed to fetch outgoing requests: {}", e);
-                    break;
-                }
-            };
-
-            if requests.is_empty() {
-                break;
+        let mut success = true;
+        let requests = match self.machine.outgoing_requests().await {
+            Ok(r) => r,
+            Err(e) => {
+                log::error!("Failed to fetch outgoing requests: {}", e);
+                return false;
             }
+        };
 
-            for req in requests {
-                match req.request() {
-                    AnyOutgoingRequest::KeysUpload(upload) => {
-                        match client.keys_upload(upload.clone()).await {
-                            Some(response) => {
-                                if let Err(e) = self
-                                    .machine
-                                    .mark_request_as_sent(req.request_id(), &response)
-                                    .await
-                                {
-                                    log::error!("Failed to mark keys upload as sent: {}", e);
-                                }
-                            }
-                            None => {
-                                log::warn!("Failed to upload keys; will retry");
+        for req in requests {
+            match req.request() {
+                AnyOutgoingRequest::KeysUpload(upload) => {
+                    match client.keys_upload(upload.clone()).await {
+                        Some(response) => {
+                            if let Err(e) = self.machine.mark_request_as_sent(req.request_id(), &response).await {
+                                log::error!("Failed to mark keys upload as sent: {}", e);
                             }
                         }
-                    }
-                    AnyOutgoingRequest::KeysQuery(query) => {
-                        let mut req_body = ruma::api::client::keys::get_keys::v3::Request::new();
-                        req_body.timeout = query.timeout;
-                        req_body.device_keys = query.device_keys.clone();
-                        match client.keys_query(req_body).await {
-                            Some(response) => {
-                                if let Err(e) = self
-                                    .machine
-                                    .mark_request_as_sent(req.request_id(), &response)
-                                    .await
-                                {
-                                    log::error!("Failed to mark keys query as sent: {}", e);
-                                }
-                            }
-                            None => {
-                                log::warn!("Failed to query keys; will retry");
-                            }
+                        None => {
+                            log::warn!("Failed to upload keys; will retry");
+                            success = false;
                         }
                     }
-                    AnyOutgoingRequest::KeysClaim(claim) => {
-                        match client.keys_claim(claim.clone()).await {
-                            Some(response) => {
-                                if let Err(e) = self
-                                    .machine
-                                    .mark_request_as_sent(req.request_id(), &response)
-                                    .await
-                                {
-                                    log::error!("Failed to mark keys claim as sent: {}", e);
-                                }
-                            }
-                            None => {
-                                log::warn!("Failed to claim keys; will retry");
-                            }
-                        }
-                    }
-                    _ => {}
                 }
+                AnyOutgoingRequest::KeysQuery(query) => {
+                    let mut req_body = ruma::api::client::keys::get_keys::v3::Request::new();
+                    req_body.timeout = query.timeout;
+                    req_body.device_keys = query.device_keys.clone();
+                    match client.keys_query(req_body).await {
+                        Some(response) => {
+                            if let Err(e) = self.machine.mark_request_as_sent(req.request_id(), &response).await {
+                                log::error!("Failed to mark keys query as sent: {}", e);
+                            }
+                        }
+                        None => {
+                            log::warn!("Failed to query keys; will retry");
+                            success = false;
+                        }
+                    }
+                }
+                AnyOutgoingRequest::KeysClaim(claim) => {
+                    match client.keys_claim(claim.clone()).await {
+                        Some(response) => {
+                            if let Err(e) = self.machine.mark_request_as_sent(req.request_id(), &response).await {
+                                log::error!("Failed to mark keys claim as sent: {}", e);
+                            }
+                        }
+                        None => {
+                            log::warn!("Failed to claim keys; will retry");
+                            success = false;
+                        }
+                    }
+                }
+                _ => {}
             }
         }
 
         if let Err(e) = self.machine.store().save().await {
             log::error!("Failed to save crypto store: {}", e);
+            success = false;
         }
 
         let state = fs::read(self.dir.path().join(STATE_STORE_DATABASE_NAME))
@@ -285,5 +359,28 @@ impl EncryptionHelper {
             .await
             .unwrap_or_default();
         self.data_layer.save_matrix_store(&state, &crypto);
+        success
     }
+
+    pub fn spawn_sync_loop(self: Arc<Self>, client: crate::as_client::MatrixAsClient) {
+        tokio::spawn(async move {
+            let mut failures = 0u32;
+            loop {
+                let ok = self.process_outgoing_requests(&client).await;
+                if ok {
+                    failures = 0;
+                } else {
+                    failures += 1;
+                    if failures >= 3 {
+                        log::error!("Encryption sync failed 3 times in a row. Will keep retrying every 2s.");
+                        failures = 0;
+                    } else {
+                        log::warn!("Failed to process encryption requests; will retry");
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        });
+    }
+
 }

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -15,30 +15,34 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static BOT_CREATED: AtomicBool = AtomicBool::new(false);
 
 pub struct MatrixBot {
     pub business_logic_context: BusinessLogicContext,
     as_client: MatrixAsClient,
-    encryption: EncryptionHelper,
+    encryption: Arc<EncryptionHelper>,
     room_encryption: Mutex<HashMap<String, bool>>,
 }
 
 impl MatrixBot {
     pub async fn new(data_layer: DataLayer, lnbits_client: LNBitsClient, config: &Config) -> Self {
-        let ctx = BusinessLogicContext::new(lnbits_client, data_layer.clone(), config);
-        let mut as_client = MatrixAsClient::new(config, data_layer.clone());
-        as_client.load_auth();
-        if !as_client.has_access_token() {
-            as_client.login().await;
+        if BOT_CREATED.swap(true, Ordering::SeqCst) {
+            panic!("MatrixBot initialized multiple times");
         }
-        let encryption = EncryptionHelper::new(&data_layer, config).await;
+        let ctx = BusinessLogicContext::new(lnbits_client, data_layer.clone(), config);
+        let as_client = MatrixAsClient::new(config, data_layer.clone());
+        as_client.create_device_msc4190().await;
+
+        let encryption = Arc::new(EncryptionHelper::new(&data_layer, config).await);
+        encryption.clone().spawn_sync_loop(as_client.clone());
         let bot = MatrixBot {
             business_logic_context: ctx,
             as_client,
-            encryption,
+            encryption: encryption.clone(),
             room_encryption: Mutex::new(HashMap::new()),
         };
-        bot.encryption.process_outgoing_requests(&bot.as_client).await;
         bot
     }
 
@@ -59,11 +63,20 @@ impl MatrixBot {
         Ok(())
     }
 
-    pub async fn handle_transaction_events(self: Arc<Self>, events: Vec<Value>, send_to_device: Vec<Value>) {
-        self
-            .encryption
-            .receive_to_device(send_to_device, &self.as_client)
-            .await;
+    pub async fn handle_transaction_events(
+        self: Arc<Self>,
+        events: Vec<Value>,
+        send_to_device: Vec<Value>,
+        device_lists: Option<Value>,
+        otk_counts: Option<Value>,
+    ) {
+        self.encryption.receive_to_device(send_to_device).await;
+        if let Some(lists) = device_lists {
+            self.encryption.receive_device_lists(lists).await;
+        }
+        if let Some(counts) = otk_counts {
+            self.encryption.receive_otk_counts(counts).await;
+        }
         for ev in events {
             let event_type = ev.get("type").and_then(|v| v.as_str());
             match event_type {
@@ -95,7 +108,7 @@ impl MatrixBot {
                         }
                         if let Some(body) = self
                             .encryption
-                            .decrypt_event(room_id, &ev, &self.as_client)
+                            .decrypt_event(room_id, &ev)
                             .await
                         {
                             self.clone().handle_message(room_id, sender, &body, None).await;
@@ -240,10 +253,7 @@ impl MatrixBot {
 
     async fn send_message(&self, room_id: &str, body: &str) {
         if self.room_is_encrypted(room_id).await {
-            let (event_type, content) = self
-                .encryption
-                .encrypt_text(room_id, body, &self.as_client)
-                .await;
+            let (event_type, content) = self.encryption.encrypt_text(room_id, body).await;
             self.as_client.send_raw(room_id, &event_type, content).await;
         } else {
             self.as_client.send_text(room_id, body).await;
@@ -254,10 +264,7 @@ impl MatrixBot {
         use crate::matrix_bot::utils::markdown_to_html;
         let html = markdown_to_html(body);
         if self.room_is_encrypted(room_id).await {
-            let (event_type, content) = self
-                .encryption
-                .encrypt_html(room_id, body, &html, &self.as_client)
-                .await;
+            let (event_type, content) = self.encryption.encrypt_html(room_id, body, &html).await;
             self.as_client.send_raw(room_id, &event_type, content).await;
         } else {
             self.as_client.send_formatted(room_id, body, &html).await;


### PR DESCRIPTION
## Summary
- create a device using MSC4190 and authenticate all requests via AS token with device parameters
- drop the obsolete `client_auth` table and remove login logic
- simplify MatrixBot initialization
- use `auth_query()` for MSC4190 device creation
