### PR TITLE
Fix MSC4190 device creation

### DIFF
--- a/src/application_service/registration.rs
+++ b/src/application_service/registration.rs
@@ -40,6 +40,9 @@ pub struct Registration {
 
     #[serde(rename = "org.matrix.msc3202", skip_serializing_if = "Option::is_none")]
     pub msc3202: Option<bool>,
+
+    #[serde(rename = "io.element.msc4190", skip_serializing_if = "Option::is_none")]
+    pub io_element_msc4190: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/bin/generate_registration.rs
+++ b/src/bin/generate_registration.rs
@@ -46,13 +46,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         app_token: as_token,
         server_token: hs_token,
         sender_localpart,
-        rate_limited: None,
+        rate_limited: Some(false),
         namespaces,
         protocols: vec![],
         soru_ephemeral_events: Some(true),
         ephemeral_events: None,
         receive_ephemeral: Some(true),
         msc3202: None,
+        io_element_msc4190: Some(true),
     };
 
     let yaml = serde_yaml::to_string(&registration)?;

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -4,6 +4,7 @@ use matrix_sdk_sqlite::{SqliteCryptoStore, STATE_STORE_DATABASE_NAME};
 use ruma::{OwnedDeviceId, OwnedRoomId, OwnedUserId};
 use tempfile::TempDir;
 use tokio::fs;
+use tokio::sync::Mutex;
 use crate::data_layer::data_layer::DataLayer;
 use crate::config::config::Config;
 
@@ -23,6 +24,7 @@ pub struct EncryptionHelper {
     machine: OlmMachine,
     data_layer: DataLayer,
     dir: TempDir,
+    pending: tokio::sync::Mutex<Vec<(OwnedRoomId, serde_json::Value)>>,
 }
 
 impl EncryptionHelper {
@@ -53,7 +55,7 @@ impl EncryptionHelper {
             .await
             .expect("create olm machine");
 
-        EncryptionHelper { machine, data_layer: data_layer.clone(), dir }
+        EncryptionHelper { machine, data_layer: data_layer.clone(), dir, pending: Mutex::new(Vec::new()) }
     }
 
     pub async fn encrypt_text(&self, room_id: &str, body: &str) -> (String, serde_json::Value) {
@@ -124,7 +126,7 @@ impl EncryptionHelper {
         )
     }
 
-    pub async fn receive_to_device(&self, events: Vec<serde_json::Value>) {
+    pub async fn receive_to_device(&self, events: Vec<serde_json::Value>) -> Vec<(String, String, String)> {
         use matrix_sdk_crypto::{EncryptionSyncChanges};
         use ruma::{api::client::sync::sync_events::DeviceLists, serde::Raw, OneTimeKeyAlgorithm, UInt, events::AnyToDeviceEvent};
         use std::collections::BTreeMap;
@@ -158,6 +160,8 @@ impl EncryptionHelper {
             .await
             .unwrap_or_default();
         self.data_layer.save_matrix_store(&state, &crypto);
+
+        self.retry_pending_events().await
     }
 
     pub async fn receive_device_lists(&self, lists: serde_json::Value) {
@@ -233,18 +237,41 @@ impl EncryptionHelper {
     }
 
     pub async fn decrypt_event(&self, room_id: &str, event: &serde_json::Value) -> Option<String> {
+        let room_id: OwnedRoomId = room_id.parse().ok()?;
+        self.decrypt_event_internal(&room_id, event, true).await
+    }
+
+    async fn decrypt_event_internal(
+        &self,
+        room_id: &OwnedRoomId,
+        event: &serde_json::Value,
+        queue_on_missing: bool,
+    ) -> Option<String> {
         use matrix_sdk_crypto::{DecryptionSettings, TrustRequirement};
         use matrix_sdk_crypto::types::events::room::encrypted::EncryptedEvent;
         use ruma::{serde::Raw, events::{AnyMessageLikeEvent, MessageLikeEvent, room::message::MessageType}};
 
         let raw: Raw<EncryptedEvent> = serde_json::value::to_raw_value(event).ok().map(Raw::from_json)?;
-        let room_id: OwnedRoomId = room_id.parse().ok()?;
         let settings = DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
-        let decrypted = self
+        let decrypted = match self
             .machine
-            .decrypt_room_event(&raw, &room_id, &settings)
+            .decrypt_room_event(&raw, room_id, &settings)
             .await
-            .ok()?;
+        {
+            Ok(ev) => ev,
+            Err(matrix_sdk_crypto::MegolmError::MissingRoomKey(_)) => {
+                if queue_on_missing {
+                    log::debug!("Missing room key, queueing event for retry");
+                    {
+                        let mut p = self.pending.lock().await;
+                        p.push((room_id.clone(), event.clone()));
+                    }
+                    let _ = self.machine.request_room_key(&raw, room_id).await;
+                }
+                return None;
+            }
+            Err(_) => return None,
+        };
 
         if let Err(e) = self.machine.store().save().await {
             log::error!("Failed to save crypto store: {}", e);
@@ -266,6 +293,145 @@ impl EncryptionHelper {
             }
         }
         None
+    }
+
+    pub async fn process_outgoing_requests(&self, client: &crate::as_client::MatrixAsClient) {
+        use matrix_sdk_crypto::types::requests::AnyOutgoingRequest;
+        use ruma::api::client::keys::{get_keys};
+        
+        let requests = self.machine.outgoing_requests().await.unwrap_or_default();
+        for req in requests {
+            match req.request() {
+                AnyOutgoingRequest::KeysUpload(upload) => {
+                    match client.keys_upload(upload.clone()).await {
+                        Some((resp, status)) if status.is_success() => {
+                            self.machine
+                                .mark_request_as_sent(req.request_id(), &resp)
+                                .await
+                                .unwrap();
+                        }
+                        Some((_, status)) => {
+                            log::warn!("keys_upload failed with status {}", status.as_u16());
+                            self.machine
+                                .mark_request_as_sent(
+                                    req.request_id(),
+                                    &ruma::api::client::keys::upload_keys::v3::Response::new(std::collections::BTreeMap::new()),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                        None => {
+                            log::warn!("keys_upload request failed");
+                            self.machine
+                                .mark_request_as_sent(
+                                    req.request_id(),
+                                    &ruma::api::client::keys::upload_keys::v3::Response::new(std::collections::BTreeMap::new()),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                    }
+                }
+                AnyOutgoingRequest::KeysQuery(query) => {
+                    let mut body = get_keys::v3::Request::new();
+                    body.device_keys = query.device_keys.clone();
+                    match client.keys_query(body).await {
+                        Some((resp, status)) if status.is_success() => {
+                            self.machine
+                                .mark_request_as_sent(req.request_id(), &resp)
+                                .await
+                                .unwrap();
+                        }
+                        Some((_, status)) => {
+                            log::warn!("keys_query failed with status {}", status.as_u16());
+                            self.machine
+                                .mark_request_as_sent(
+                                    req.request_id(),
+                                    &ruma::api::client::keys::get_keys::v3::Response::new(),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                        None => {
+                            log::warn!("keys_query request failed");
+                            self.machine
+                                .mark_request_as_sent(
+                                    req.request_id(),
+                                    &ruma::api::client::keys::get_keys::v3::Response::new(),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                    }
+                }
+                AnyOutgoingRequest::KeysClaim(claim) => {
+                    match client.keys_claim(claim.clone()).await {
+                        Some((resp, status)) if status.is_success() => {
+                            self.machine
+                                .mark_request_as_sent(req.request_id(), &resp)
+                                .await
+                                .unwrap();
+                        }
+                        Some((_, status)) => {
+                            log::warn!("keys_claim failed with status {}", status.as_u16());
+                            self.machine
+                                .mark_request_as_sent(
+                                    req.request_id(),
+                                    &ruma::api::client::keys::claim_keys::v3::Response::new(std::collections::BTreeMap::new()),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                        None => {
+                            log::warn!("keys_claim request failed");
+                            self.machine
+                                .mark_request_as_sent(
+                                    req.request_id(),
+                                    &ruma::api::client::keys::claim_keys::v3::Response::new(std::collections::BTreeMap::new()),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                    }
+                }
+                AnyOutgoingRequest::ToDeviceRequest(td) => {
+                    if let Some(resp) = client.send_to_device(td.clone()).await {
+                        self.machine
+                            .mark_request_as_sent(req.request_id(), &resp)
+                            .await
+                            .unwrap();
+                    }
+                }
+                _ => {}
+            }
+        }
+        self.machine.store().save().await.unwrap();
+    }
+
+    pub async fn retry_pending_events(&self) -> Vec<(String, String, String)> {
+        let mut pending = self.pending.lock().await;
+        if pending.is_empty() {
+            return Vec::new();
+        }
+        log::debug!("Retrying {} pending events", pending.len());
+        let mut results = Vec::new();
+        let mut i = 0usize;
+        while i < pending.len() {
+            let (room_id, event) = pending[i].clone();
+            if let Some(sender) = event.get("sender").and_then(|s| s.as_str()) {
+                if let Some(body) = self
+                    .decrypt_event_internal(&room_id, &event, false)
+                    .await
+                {
+                    results.push((room_id.to_string(), sender.to_string(), body));
+                    pending.remove(i);
+                    log::debug!("Pending event decrypted for room {}", room_id);
+                    continue;
+                }
+            }
+            i += 1;
+        }
+        results
     }
 
 }

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -33,16 +33,17 @@ impl MatrixBot {
         }
         let ctx = BusinessLogicContext::new(lnbits_client, data_layer.clone(), config);
         let as_client = MatrixAsClient::new(config, data_layer.clone());
-        as_client.create_device().await;
+        if let Err(e) = as_client.create_device_msc4190().await {
+            log::error!("Failed to create MSC4190 device: {}", e);
+        }
 
         let encryption = Arc::new(EncryptionHelper::new(&data_layer, config).await);
-        let bot = MatrixBot {
+        MatrixBot {
             business_logic_context: ctx,
             as_client,
             encryption: encryption.clone(),
             room_encryption: Mutex::new(HashMap::new()),
-        };
-        bot
+        }
     }
 
     pub async fn init(self: Arc<Self>) {
@@ -51,6 +52,7 @@ impl MatrixBot {
             .set_presence("online", "Ready to help")
             .await;
         self.clone().start_presence_loop();
+        self.clone().start_crypto_loop();
         log::info!("MatrixBot initialized");
     }
 
@@ -69,7 +71,10 @@ impl MatrixBot {
         device_lists: Option<Value>,
         otk_counts: Option<Value>,
     ) {
-        self.encryption.receive_to_device(send_to_device).await;
+        let new_msgs = self.encryption.receive_to_device(send_to_device).await;
+        for (room, sender, body) in new_msgs {
+            self.clone().handle_message(&room, &sender, &body, None).await;
+        }
         if let Some(lists) = device_lists {
             self.encryption.receive_device_lists(lists).await;
         }
@@ -315,6 +320,19 @@ impl MatrixBot {
                     .set_presence("online", "Ready to help")
                     .await;
                 sleep(Duration::from_secs(300)).await;
+            }
+        });
+    }
+
+    fn start_crypto_loop(self: Arc<Self>) {
+        tokio::spawn(async move {
+            loop {
+                self.encryption.process_outgoing_requests(&self.as_client).await;
+                let msgs = self.encryption.retry_pending_events().await;
+                for (room, sender, body) in msgs {
+                    self.clone().handle_message(&room, &sender, &body, None).await;
+                }
+                tokio::time::sleep(Duration::from_secs(2)).await;
             }
         });
     }


### PR DESCRIPTION
## Summary
- create MSC4190 device without specifying the device ID query
- queue encrypted events when missing keys and retry after key downloads
- handle outgoing to-device requests
- log and remove failed key upload/query/claim requests
