### PR TITLE
refractor bot logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ matrix-sdk = { version = "0.12.0", features = ["e2e-encryption", "qrcode"] }
 tokio = { version = "1.40.0", features = ["full"] }
 simple_logger = "5.0.0"
 log = "0.4.22"
-dotenv = "0.15.0"
 diesel = { version = "2.2.4", features = ["sqlite", "numeric", "chrono", "r2d2", "uuid"] }
 simple-error = "0.3.1"
 uuid = { version = "1.10.0", features = ["serde", "v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = "4.5.40"
 argfile = "0.2.1"
 wild = "2.2.1"
 url = "2.5.2"
-matrix-sdk = { version = "0.12.0", features = ["e2e-encryption", "qrcode", "testing"] }
+matrix-sdk = { version = "0.12.0", features = ["e2e-encryption", "qrcode"] }
 tokio = { version = "1.40.0", features = ["full"] }
 simple_logger = "5.0.0"
 log = "0.4.22"
@@ -30,5 +30,4 @@ tl = "0.7.8"
 lnurl-rs = "0.9.0"
 pulldown-cmark = "0.13.0"
 
-[dev-dependencies]
-matrix-sdk-test = "0.12.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ mime = "0.3.17"
 lightning-invoice = "0.33.2"
 tl = "0.7.8"
 lnurl-rs = "0.9.0"
+pulldown-cmark = "0.13.0"
 
 [dev-dependencies]
 matrix-sdk-test = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = "4.5.40"
 argfile = "0.2.1"
 wild = "2.2.1"
 url = "2.5.2"
-matrix-sdk = { version = "0.12.0", features = ["e2e-encryption", "qrcode"] }
+matrix-sdk = { version = "0.12.0", features = ["e2e-encryption", "qrcode", "testing"] }
 tokio = { version = "1.40.0", features = ["full"] }
 simple_logger = "5.0.0"
 log = "0.4.22"
@@ -28,3 +28,6 @@ mime = "0.3.17"
 lightning-invoice = "0.33.2"
 tl = "0.7.8"
 lnurl-rs = "0.9.0"
+
+[dev-dependencies]
+matrix-sdk-test = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-lightning-tip-bot"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,7 @@ pub mod config {
         ).unwrap();
 
         let matches = Command::new("LN-Matrix-Bot")
-            .version("0.9.0")
+            .version("0.9.1")
             .author("warioishere")
             .about("LN-Matrix-Bot")
             .arg(Arg::new("matrix-server")

--- a/src/matrix_bot/business_logic.rs
+++ b/src/matrix_bot/business_logic.rs
@@ -110,11 +110,13 @@ impl BusinessLogicContext {
         Ok(self.member_cache.lock().await.get(room.room_id()).cloned().unwrap_or_default())
     }
 
+    #[cfg(test)]
     pub async fn insert_member_ids(&self, room_id: OwnedRoomId, ids: Vec<OwnedUserId>) {
         let mut cache = self.member_cache.lock().await;
         cache.insert(room_id, ids);
     }
 
+    #[cfg(test)]
     pub async fn get_cached_member_ids(&self, room_id: &OwnedRoomId) -> Option<Vec<OwnedUserId>> {
         let cache = self.member_cache.lock().await;
         cache.get(room_id).cloned()

--- a/src/matrix_bot/business_logic.rs
+++ b/src/matrix_bot/business_logic.rs
@@ -13,6 +13,8 @@ use crate::matrix_bot::utils::parse_lnurl;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use matrix_sdk::{Room, RoomMemberships, room::RoomMember};
+use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId};
 
 const HELP_COMMANDS: &str = "**!help** - Read this help: `!help`\n\
 **!help-boltz-swaps** - Learn how swaps and refunds work: `!help-boltz-swaps`\n\
@@ -63,6 +65,7 @@ pub struct BusinessLogicContext  {
     data_layer: DataLayer,
     config: Config,
     pending_reverse_swaps: Arc<Mutex<HashMap<String, (u64, String)>>>,
+    member_cache: Arc<Mutex<HashMap<OwnedRoomId, Vec<OwnedUserId>>>>,
 }
 
 impl BusinessLogicContext {
@@ -75,6 +78,7 @@ impl BusinessLogicContext {
             data_layer,
             config: config.clone(),
             pending_reverse_swaps: Arc::new(Mutex::new(HashMap::new())),
+            member_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -85,6 +89,35 @@ impl BusinessLogicContext {
     pub async fn has_pending_reverse_swap(&self, sender: &str) -> bool {
         let map = self.pending_reverse_swaps.lock().await;
         map.contains_key(sender)
+    }
+
+    pub async fn update_room_members(&self, room: &Room) -> Result<(), SimpleError> {
+        let members: Vec<RoomMember> = try_with!(
+            room.members_no_sync(RoomMemberships::JOIN).await,
+            "Could not get room members"
+        );
+        let ids = members.into_iter().map(|m| m.user_id().to_owned()).collect();
+        let mut cache = self.member_cache.lock().await;
+        cache.insert(room.room_id().to_owned(), ids);
+        Ok(())
+    }
+
+    pub async fn get_or_fetch_member_ids(&self, room: &Room) -> Result<Vec<OwnedUserId>, SimpleError> {
+        if let Some(ids) = self.member_cache.lock().await.get(room.room_id()).cloned() {
+            return Ok(ids);
+        }
+        self.update_room_members(room).await?;
+        Ok(self.member_cache.lock().await.get(room.room_id()).cloned().unwrap_or_default())
+    }
+
+    pub async fn insert_member_ids(&self, room_id: OwnedRoomId, ids: Vec<OwnedUserId>) {
+        let mut cache = self.member_cache.lock().await;
+        cache.insert(room_id, ids);
+    }
+
+    pub async fn get_cached_member_ids(&self, room_id: &OwnedRoomId) -> Option<Vec<OwnedUserId>> {
+        let cache = self.member_cache.lock().await;
+        cache.get(room_id).cloned()
     }
 
     pub fn get_help_content(&self, with_prefix: bool, include_note: bool) -> String {
@@ -702,5 +735,32 @@ impl BusinessLogicContext {
                                    "Could not load invoice");
 
         Ok((invoice, wallet.in_key.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cache_roundtrip() {
+        let config = Config::new(
+            "https://example.org",
+            "@bot:example.org",
+            "pass",
+            "https://lnbits",
+            "token",
+            "apikey",
+            ":memory:",
+            "Info",
+            None,
+        );
+        let ctx = BusinessLogicContext::new(LNBitsClient::new(&config), DataLayer::new(&config), &config);
+        let room_id = OwnedRoomId::try_from("!room:example.org").unwrap();
+        let user = OwnedUserId::try_from("@alice:example.org").unwrap();
+
+        ctx.insert_member_ids(room_id.clone(), vec![user.clone()]).await;
+        let cached = ctx.get_cached_member_ids(&room_id).await;
+        assert_eq!(cached.unwrap(), vec![user]);
     }
 }

--- a/src/matrix_bot/commands.rs
+++ b/src/matrix_bot/commands.rs
@@ -147,7 +147,7 @@ pub fn show_ln_addresses(sender: &str) -> Result<Command, SimpleError> {
 pub fn fiat_to_sats(sender: &str, text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
     if split.len() < 3 {
-        bail!("Expected at least 3 arguments: !fiat-to-sats <amount> <currency>");
+        bail!("Expected 2 arguments: !fiat-to-sats <amount> <currency>");
     }
     let amount = try_with!(split[1].parse::<f64>(), "Could not parse amount");
     let currency = split[2].to_string();
@@ -157,7 +157,7 @@ pub fn fiat_to_sats(sender: &str, text: &str) -> Result<Command, SimpleError> {
 pub fn sats_to_fiat(sender: &str, text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
     if split.len() < 3 {
-        bail!("Expected at least 3 arguments: !sats-to-fiat <amount> <currency>");
+        bail!("Expected 2 arguments: !sats-to-fiat <amount> <currency>");
     }
     let amount = try_with!(split[1].parse::<u64>(), "Could not parse amount");
     let currency = split[2].to_string();
@@ -195,7 +195,7 @@ pub fn boltz_offchain_to_onchain(sender: &str, text: &str) -> Result<Command, Si
 pub fn refund(sender: &str, text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
     if split.len() < 2 {
-        bail!("Expected at least 2 arguments: !refund <swap_id>");
+        bail!("Expected 1 argument: !refund <swap_id>");
     }
     let swap_id = split[1].to_string();
     Ok(Command::Refund { sender: sender.to_string(), swap_id })

--- a/src/matrix_bot/commands.rs
+++ b/src/matrix_bot/commands.rs
@@ -175,7 +175,7 @@ pub fn link_to_zeus_wallet(sender: &str) -> Result<Command, SimpleError> {
 pub fn boltz_onchain_to_offchain(sender: &str, text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
     if split.len() < 3 {
-        bail!("Expected at least 3 arguments: !boltz-onchain-to-offchain <amount> <refund-address>");
+        bail!("Expected 2 arguments: !boltz-onchain-to-offchain <amount> <refund-address>");
     }
     let amount = try_with!(split[1].parse::<u64>(), "Could not parse amount");
     let refund_address = split[2].to_string();
@@ -185,7 +185,7 @@ pub fn boltz_onchain_to_offchain(sender: &str, text: &str) -> Result<Command, Si
 pub fn boltz_offchain_to_onchain(sender: &str, text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
     if split.len() < 3 {
-        bail!("Expected at least 3 arguments: !boltz-offchain-to-onchain <amount> <onchain-address>");
+        bail!("Expected 2 arguments: !boltz-offchain-to-onchain <amount> <onchain-address>");
     }
     let amount = try_with!(split[1].parse::<u64>(), "Could not parse amount");
     let onchain_address = split[2].to_string();

--- a/src/matrix_bot/commands.rs
+++ b/src/matrix_bot/commands.rs
@@ -48,8 +48,8 @@ impl Command {
 
 pub fn tip(sender:&str, text: &str, replyee: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
-    if split.len() < 2 {
-        bail!("Expected a at least 2 arguments")
+    if split.len() < 3 {
+        bail!("Expected at least 2 arguments: !tip <amount> <comment>")
     }
     let amount =   try_with!(split[1].parse::<u64>(), "could not parse value");
     let memo = if split.len() > 2 { Some(split[2..].join(" ") )  }
@@ -68,8 +68,8 @@ pub fn send(sender:&str,
             text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
 
-    if split.len() < 2 {
-        bail!("Expected a at least 2 arguments")
+    if split.len() < 3 {
+        bail!("Expected 2 arguments: !send <amount> <receiver> [memo]")
     }
     let amount =  try_with!(split[1].parse::<u64>(), "could not parse value");
     let recipient = String::from(split[2]);
@@ -85,7 +85,7 @@ pub fn invoice(sender:&str,
                text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
     if split.len() < 2 {
-        bail!("Expected a at least 2 arguments")
+        bail!("Expected 1 argument: !invoice <amount> [memo]")
     }
     let amount =  try_with!(split[1].parse::<u64>(), "could not parse value");
     let memo = if split.len() > 2 { Some(split[2..].join(" ") )  }
@@ -97,7 +97,7 @@ pub fn pay(sender:&str,
            text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
     if split.len() < 2 {
-        bail!("Expected a at least 2 arguments")
+        bail!("Expected 1 argument: !pay <invoice>")
     }
     let invoice = String::from(split[1]);
     Ok(Command::Pay { sender: String::from(sender),
@@ -116,7 +116,7 @@ pub fn help_boltz_swaps(with_prefix: bool, include_note: bool) -> Result<Command
 pub fn donate(sender: &str, text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
     if split.len() < 2 {
-        bail!("Expected a at least 2 arguments")
+        bail!("Expected 1 argument: !donate <amount>")
     }
     let amount =  try_with!(split[1].parse::<u64>(), "Could not parse value");
     Ok(Command::Donate { sender: String::from(sender),
@@ -134,7 +134,7 @@ pub fn version() -> Result<Command, SimpleError> {
 pub fn generate_ln_address(sender: &str, text: &str) -> Result<Command, SimpleError> {
     let split = text.split_whitespace().collect::<Vec<&str>>();
     if split.len() < 2 {
-        bail!("Expected a at least 2 arguments")
+        bail!("Expected 1 argument: !generate-ln-address <username>")
     }
     let username = split[1].to_string();
     Ok(Command::GenerateLnAddress { sender: sender.to_string(), username })

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -526,14 +526,9 @@ pub mod matrix_bot {
                         match command {
                             Err(error) => {
                                 log::warn!("Error occurred while extracting command {:?}..", error);
-                                let result = send_reply_to_event_in_room(&room,
-                                                                         &event,
-                                                                         "Unknown command, please use `help` for list of commands").await;
-                                match result {
-                                    Err(error) => {
-                                        log::warn!("Could not even send error message due to {:?}..", error);
-                                    }
-                                    _ => { /* ignore */}
+                                let reply = error.to_string();
+                                if let Err(err) = send_reply_to_event_in_room(&room, &event, reply.as_str()).await {
+                                    log::warn!("Could not even send error message due to {:?}..", err);
                                 }
                                 return
                             }
@@ -751,6 +746,12 @@ mod tests {
             Some(Command::Tip { amount, .. }) => assert_eq!(amount, 100),
             _ => panic!("expected tip"),
         }
+    }
+
+    #[test]
+    fn parse_tip_missing_argument() {
+        let err = parse_command("!tip").unwrap_err();
+        assert!(err.to_string().contains("Expected"));
     }
 
     #[test]

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -752,7 +752,7 @@ mod tests {
 
     #[test]
     fn parse_tip_command() {
-        let cmd = parse_command("!tip 100").unwrap();
+        let cmd = parse_command("!tip 100 thanks").unwrap();
         match cmd {
             Some(Command::Tip { amount, .. }) => assert_eq!(amount, 100),
             _ => panic!("expected tip"),

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -694,12 +694,12 @@ pub mod matrix_bot {
         }
 
         fn bot_name(&self) -> String {
-            let parts: Vec<&str> = self.config.matrix_server.split(':').collect();
-            if parts.is_empty() || parts[0].len() < 1 {
-                log::warn!("Could not parse my own name from config, please check it");
-                "".to_string()
-            } else {
-                parts[0][1..].to_owned()
+            match UserId::parse(self.config.matrix_username.as_str()) {
+                Ok(user_id) => user_id.localpart().to_owned(),
+                Err(e) => {
+                    log::warn!("Could not parse my own name from config: {:?}", e);
+                    "".to_string()
+                }
             }
         }
 

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -202,7 +202,10 @@ pub mod matrix_bot {
             Some(Command::Pay { .. }) => pay(sender, msg_body.as_str()),
             Some(Command::HelpBoltzSwaps { .. }) => help_boltz_swaps(!is_direct, is_encrypted),
             Some(Command::Help { .. }) => help(!is_direct, is_encrypted),
-            Some(Command::Donate { amount, .. }) => donate(sender, msg_body.as_str()),
+            Some(Command::Donate { amount, .. }) => Ok(Command::Donate {
+                sender: sender.to_string(),
+                amount,
+            }),
             Some(Command::Party { .. }) => party(),
             Some(Command::Version { .. }) => version(),
             Some(Command::GenerateLnAddress { .. }) => generate_ln_address(sender, msg_body.as_str()),

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -766,6 +766,24 @@ mod tests {
     }
 
     #[test]
+    fn parse_boltz_onchain_to_offchain_missing_argument() {
+        let err = parse_command("!boltz-onchain-to-offchain 100").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Expected 2 arguments: !boltz-onchain-to-offchain <amount> <refund-address>"
+        );
+    }
+
+    #[test]
+    fn parse_boltz_offchain_to_onchain_missing_argument() {
+        let err = parse_command("!boltz-offchain-to-onchain 100").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Expected 2 arguments: !boltz-offchain-to-onchain <amount> <onchain-address>"
+        );
+    }
+
+    #[test]
     fn parse_send_command() {
         let cmd = parse_command("!send 50 @bob:example.org").unwrap();
         match cmd {

--- a/src/matrix_bot/mod.rs
+++ b/src/matrix_bot/mod.rs
@@ -778,6 +778,69 @@ mod tests {
     }
 
     #[test]
+    fn parse_send_missing_argument() {
+        let err = parse_command("!send 50").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Expected 2 arguments: !send <amount> <receiver> [memo]"
+        );
+    }
+
+    #[test]
+    fn parse_invoice_missing_argument() {
+        let err = parse_command("!invoice").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Expected 1 argument: !invoice <amount> [memo]"
+        );
+    }
+
+    #[test]
+    fn parse_pay_missing_argument() {
+        let err = parse_command("!pay").unwrap_err();
+        assert_eq!(err.to_string(), "Expected 1 argument: !pay <invoice>");
+    }
+
+    #[test]
+    fn parse_donate_missing_argument() {
+        let err = parse_command("!donate").unwrap_err();
+        assert_eq!(err.to_string(), "Expected 1 argument: !donate <amount>");
+    }
+
+    #[test]
+    fn parse_generate_ln_address_missing_argument() {
+        let err = parse_command("!generate-ln-address").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Expected 1 argument: !generate-ln-address <username>"
+        );
+    }
+
+    #[test]
+    fn parse_fiat_to_sats_missing_argument() {
+        let err = parse_command("!fiat-to-sats 10").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Expected 2 arguments: !fiat-to-sats <amount> <currency>"
+        );
+    }
+
+    #[test]
+    fn parse_sats_to_fiat_missing_argument() {
+        let err = parse_command("!sats-to-fiat 10").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Expected 2 arguments: !sats-to-fiat <amount> <currency>"
+        );
+    }
+
+    #[test]
+    fn parse_refund_missing_argument() {
+        let err = parse_command("!refund").unwrap_err();
+        assert_eq!(err.to_string(), "Expected 1 argument: !refund <swap_id>");
+    }
+
+    #[test]
     fn parse_boltz_onchain_to_offchain_missing_argument() {
         let err = parse_command("!boltz-onchain-to-offchain 100").unwrap_err();
         assert_eq!(

--- a/src/matrix_bot/utils.rs
+++ b/src/matrix_bot/utils.rs
@@ -18,7 +18,7 @@ pub fn markdown_to_html(input: &str) -> String {
     let parser = parser.map(|event| match event {
         Event::SoftBreak => Event::HardBreak,
         // ensure placeholders like <invoice> are shown literally
-        Event::Html(text) => Event::Text(text.into_string().into()),
+        Event::Html(text) | Event::InlineHtml(text) => Event::Text(text.into_string().into()),
         other => other,
     });
     let mut html_output = String::new();
@@ -43,6 +43,6 @@ mod tests {
     fn keeps_angle_brackets() {
         let input = "Expected 1 argument: !pay <invoice>";
         let html = markdown_to_html(input);
-        assert!(html.contains("!pay <invoice>"));
+        assert!(html.contains("&lt;invoice&gt;"));
     }
 }

--- a/src/matrix_bot/utils.rs
+++ b/src/matrix_bot/utils.rs
@@ -17,6 +17,8 @@ pub fn markdown_to_html(input: &str) -> String {
     let parser = Parser::new_ext(input, Options::ENABLE_STRIKETHROUGH);
     let parser = parser.map(|event| match event {
         Event::SoftBreak => Event::HardBreak,
+        // ensure placeholders like <invoice> are shown literally
+        Event::Html(text) => Event::Text(text.into_string().into()),
         other => other,
     });
     let mut html_output = String::new();
@@ -35,5 +37,12 @@ mod tests {
         assert!(html.contains("<strong>bold</strong>"));
         assert!(html.contains("<code>code</code>"));
         assert!(html.contains("<br"));
+    }
+
+    #[test]
+    fn keeps_angle_brackets() {
+        let input = "Expected 1 argument: !pay <invoice>";
+        let html = markdown_to_html(input);
+        assert!(html.contains("!pay <invoice>"));
     }
 }


### PR DESCRIPTION
## Summary
- parse bot name from `matrix_username` rather than the homeserver url
- Use structured command dispatch
- Simplify room member lookup
- Use pulldown-cmark for markdown conversion
- Create reusable async status poller
- if an arugment is missing, bot now replies with the arg that is missing instead of "unknown command"
- remove unused dependencies
- add a little cache for room-members to speed up replies on bigger rooms
- bugfixing
