### PR TITLE
Display routing fee errors to users instead of generic error message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-lightning-tip-bot"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,7 @@ pub mod config {
         ).unwrap();
 
         let matches = Command::new("LN-Matrix-Bot")
-            .version("0.9.3")
+            .version("0.9.4")
             .author("warioishere")
             .about("LN-Matrix-Bot")
             .arg(Arg::new("matrix-server")

--- a/src/matrix_bot/business_logic.rs
+++ b/src/matrix_bot/business_logic.rs
@@ -59,8 +59,6 @@ fn help_boltz_swaps_text(with_prefix: bool) -> String {
 
 pub const VERIFICATION_NOTE: &str = "Don't worry about the red 'Not verified' warning. This is a limitation of bots in the Matrix ecosystem. Your messages are still encrypted and the admin cannot read them.";
 
-const INSUFFICIENT_BALANCE_MESSAGE: &str = "Insufficient balance.";
-
 #[derive(Clone)]
 pub struct BusinessLogicContext  {
     pub lnbits_client: LNBitsClient,
@@ -909,12 +907,13 @@ mod tests {
             &config,
         );
 
+        let insufficient_balance_msg = "Insufficient balance.";
         let result = ctx.handle_donate_send_result(Ok(CommandReply::text_only(
-            INSUFFICIENT_BALANCE_MESSAGE,
+            insufficient_balance_msg,
         )));
 
         let reply = result.expect("donation should forward insufficient balance reply");
-        assert_eq!(reply.text.as_deref(), Some(INSUFFICIENT_BALANCE_MESSAGE));
+        assert_eq!(reply.text.as_deref(), Some(insufficient_balance_msg));
     }
 
     #[test]

--- a/src/matrix_bot/business_logic.rs
+++ b/src/matrix_bot/business_logic.rs
@@ -98,8 +98,8 @@ impl BusinessLogicContext {
             Ok(_) => Ok(None),
             Err(err) => {
                 let err_msg = err.to_string();
-                if err_msg == INSUFFICIENT_BALANCE_MESSAGE {
-                    return Ok(Some(CommandReply::text_only(INSUFFICIENT_BALANCE_MESSAGE)));
+                if BusinessLogicContext::is_insufficient_balance_text(&err_msg) {
+                    return Ok(Some(CommandReply::text_only(&err_msg)));
                 }
 
                 Err(SimpleError::new(format!("{}, {}", context, err_msg)))
@@ -808,7 +808,7 @@ impl BusinessLogicContext {
 
         if let Err(err) = self.lnbits_client.pay(&wallet, &payment_params).await {
             if BusinessLogicContext::payment_error_is_insufficient_balance(&err) {
-                return Err(SimpleError::new(INSUFFICIENT_BALANCE_MESSAGE));
+                return Err(SimpleError::new(err.to_string()));
             }
 
             return Err(SimpleError::new(format!("Could not perform payment: {}", err)));

--- a/src/matrix_bot/business_logic.rs
+++ b/src/matrix_bot/business_logic.rs
@@ -75,7 +75,7 @@ impl BusinessLogicContext {
     fn is_insufficient_balance_text(text: &str) -> bool {
         let normalized = text.trim();
         let normalized = normalized.trim_end_matches('.');
-        normalized.eq_ignore_ascii_case("insufficient balance")
+        normalized.eq_ignore_ascii_case("insufficient balance") || normalized.to_lowercase().contains("routing fee")
     }
 
     fn payment_error_is_insufficient_balance(pay_error: &PayError) -> bool {
@@ -915,5 +915,23 @@ mod tests {
 
         let reply = result.expect("donation should forward insufficient balance reply");
         assert_eq!(reply.text.as_deref(), Some(INSUFFICIENT_BALANCE_MESSAGE));
+    }
+
+    #[test]
+    fn is_insufficient_balance_text_detects_routing_fee_error() {
+        let routing_fee_error = "You must reserve at least (12  sat) to cover potential routing fees.";
+        assert!(BusinessLogicContext::is_insufficient_balance_text(routing_fee_error));
+    }
+
+    #[test]
+    fn is_insufficient_balance_text_detects_insufficient_balance() {
+        assert!(BusinessLogicContext::is_insufficient_balance_text("Insufficient balance"));
+        assert!(BusinessLogicContext::is_insufficient_balance_text("insufficient balance."));
+    }
+
+    #[test]
+    fn is_insufficient_balance_text_ignores_other_errors() {
+        assert!(!BusinessLogicContext::is_insufficient_balance_text("Some other error"));
+        assert!(!BusinessLogicContext::is_insufficient_balance_text("Payment failed"));
     }
 }


### PR DESCRIPTION
## Summary

When users try to spend almost their entire balance using `send`, `donate`, `tip`, or `pay` commands, LNbits returns a routing fee reservation error. Previously, this error was treated as a generic error and the bot showed "I seem to experience a problem, pls try again later" instead of the helpful error message.

This PR fixes that by updating the error detection to catch routing fee errors and display them as user-friendly messages.

## Changes

- Updated `is_insufficient_balance_text()` to detect errors containing "routing fee"
- Added test cases to verify routing fee and insufficient balance detection work correctly
- All payment commands (send, donate, tip, pay) now properly display routing fee errors to users

Fixes https://github.com/warioishere/matrix-lightning-tip-bot/issues/50